### PR TITLE
Fix handling of empty text elements in nested lists

### DIFF
--- a/packages/plugins/lists/src/utils/deserializeListNodes.ts
+++ b/packages/plugins/lists/src/utils/deserializeListNodes.ts
@@ -1,7 +1,7 @@
 import type { YooEditor, YooptaBlockData } from '@yoopta/editor';
 import { deserializeTextNodes, generateId } from '@yoopta/editor';
 import type { Descendant} from 'slate';
-import { Element } from 'slate';
+import { Element, Text } from 'slate';
 
 type ListHTMLElement = HTMLUListElement | HTMLOListElement | HTMLElement;
 
@@ -86,6 +86,15 @@ export function deserializeListNodes(
 
           return acc;
         }, []);
+        // fix: unnecessary text elements only with line breaks in nested lists
+        while (children.length > 0) {
+          const lastChild = children[children.length - 1];
+          if (Text.isText(lastChild) && lastChild.text.trim() === '') {
+            children.pop();
+          } else {
+            break;
+          }
+        }
 
         blockData = {
           id: generateId(),


### PR DESCRIPTION
Remove unnecessary text elements only with line breaks in nested lists

## Description
the html
<img width="313" height="319" alt="Screenshot 2025-11-10 100730" src="https://github.com/user-attachments/assets/6bc15c15-cd16-4d85-95b2-34cbce6e283f" />

how it looks
<img width="318" height="413" alt="Screenshot 2025-11-10 093541" src="https://github.com/user-attachments/assets/7c1224e9-617f-48eb-a231-edc583a02748" />

how it should look
<img width="306" height="267" alt="Screenshot 2025-11-10 092931" src="https://github.com/user-attachments/assets/a6bbf7e6-dbc7-45c4-be22-65b808c34a8d" />

the cause
<img width="673" height="482" alt="Screenshot 2025-11-10 093834" src="https://github.com/user-attachments/assets/89154ee3-6bb8-4e13-afc3-b838bd59094f" />

