### PR TITLE
feat: add color removal functionality to highlight color picker

### DIFF
--- a/packages/core/ui/src/highlight-color-picker/highlight-color-picker.css
+++ b/packages/core/ui/src/highlight-color-picker/highlight-color-picker.css
@@ -157,7 +157,18 @@
 
 .yoopta-ui-highlight-color-picker-preset[data-selected='true'] {
   border-color: hsl(var(--yoopta-ui-ring));
-  box-shadow: 0 0 0 2px hsl(var(--yoopta-ui-ring) / 0.35);
+  box-shadow: 0 0 0 0px hsl(var(--yoopta-ui-ring) / 0.35);
+}
+
+/* Remove Color Preset */
+.yoopta-ui-highlight-color-picker-preset-remove {
+  background:
+    linear-gradient(to top right,
+      transparent calc(50% - 1px),
+      hsl(0 65% 55%) calc(50% - 1px),
+      hsl(0 65% 55%) calc(50% + 1px),
+      transparent calc(50% + 1px)),
+    linear-gradient(to right bottom, hsl(var(--yoopta-ui-background)) 50%, hsl(var(--yoopta-ui-border)) 50%) !important;
 }
 
 /* Hex Row */

--- a/packages/core/ui/src/highlight-color-picker/highlight-color-picker.tsx
+++ b/packages/core/ui/src/highlight-color-picker/highlight-color-picker.tsx
@@ -156,6 +156,19 @@ export const HighlightColorPicker = forwardRef<HTMLDivElement, HighlightColorPic
       [mode, value, onChange, debouncedOnChange],
     );
 
+    // Handler for removing color (set to undefined)
+    const handleRemoveColor = useCallback(() => {
+      debouncedOnChange.cancel();
+
+      if (mode === 'backgroundColor') {
+        setColor(undefined);
+        onChange?.({ ...value, backgroundColor: undefined });
+      } else {
+        setTextColor(undefined);
+        onChange?.({ ...value, color: undefined });
+      }
+    }, [mode, value, onChange, debouncedOnChange]);
+
     const currentColor = mode === 'backgroundColor' ? color : textColor;
 
     const trigger = cloneElement(children, {
@@ -218,6 +231,13 @@ export const HighlightColorPicker = forwardRef<HTMLDivElement, HighlightColorPic
 
             {presets.length > 0 && (
               <div className="yoopta-ui-highlight-color-picker-presets">
+                <button
+                  type="button"
+                  className="yoopta-ui-highlight-color-picker-preset yoopta-ui-highlight-color-picker-preset-remove"
+                  data-selected={!currentColor}
+                  onClick={handleRemoveColor}
+                  aria-label={`Remove ${mode === 'backgroundColor' ? 'background' : 'text'} color`}
+                />
                 {presets.map((presetColor) => {
                   const isSelected = currentColor?.toLowerCase() === presetColor.toLowerCase();
                   return (


### PR DESCRIPTION
- Implemented a button to remove the selected color, allowing users to reset the background or text color.
- Updated CSS for the color preset button to include a new style for the removal action.
- Enhanced user experience by providing a clear method to clear color selections.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
