### PR TITLE
Feat: add math plugin support for inline and block equations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ web/
 └── next-app-example/ # Development playground and examples
 ```
 
-**Available Plugins**: accordion, blockquote, callout, carousel, code, divider, embed, emoji, file, headings, image, link, lists, mention, paragraph, steps, table, table-of-contents, tabs, video
+**Available Plugins**: accordion, blockquote, callout, carousel, code, divider, embed, emoji, file, headings, image, link, lists, math, mention, paragraph, steps, table, table-of-contents, tabs, video
 
 ### YooEditor API
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See what you can build with Yoopta:
 - **Drag and drop** — Reorder blocks with nested depth support; optional `SortableBlock` for custom DnD
 - **Selection box** — Multi-block selection for copy, delete, or bulk operations
 - **Slash command & action menu** — Type `/` for block insertion; floating block actions (+, drag handle, block options)
-- **Inline elements** — Links, @mentions, and custom inline nodes within text
+- **Inline elements** — Links, @mentions, emojis, inline math (KaTeX), and custom inline nodes within text
 - **Export** — HTML, Markdown, plain text, email template; get/set content as Yoopta JSON
 - **Real-time collaboration** (`@yoopta/collaboration`) — Multi-user editing with Yjs CRDT, presence (awareness), remote cursors, and WebSocket provider; optional package for collaborative documents
 - **Events** — `editor.on('change' | 'focus' | 'blur' | 'path-change' | 'block:copy')` for sync, analytics, or custom logic
@@ -94,7 +94,7 @@ See what you can build with Yoopta:
 yarn add slate slate-react slate-dom @yoopta/editor
 
 # Add plugins you need
-yarn add @yoopta/paragraph @yoopta/headings @yoopta/lists @yoopta/blockquote @yoopta/code @yoopta/image @yoopta/video @yoopta/embed @yoopta/file @yoopta/callout @yoopta/divider @yoopta/accordion @yoopta/table @yoopta/tabs @yoopta/steps @yoopta/mention @yoopta/links
+yarn add @yoopta/paragraph @yoopta/headings @yoopta/lists @yoopta/blockquote @yoopta/code @yoopta/image @yoopta/video @yoopta/embed @yoopta/file @yoopta/callout @yoopta/divider @yoopta/accordion @yoopta/table @yoopta/tabs @yoopta/steps @yoopta/mention @yoopta/math @yoopta/links
 
 # Add marks for text formatting
 yarn add @yoopta/marks
@@ -293,27 +293,28 @@ export default function Editor() {
 
 ### Plugins
 
-| Package                                                           | Description                           |
-| ----------------------------------------------------------------- | ------------------------------------- |
-| [@yoopta/paragraph](./packages/plugins/paragraph)                 | Basic text paragraph                  |
-| [@yoopta/headings](./packages/plugins/headings)                   | H1, H2, H3 headings                   |
-| [@yoopta/lists](./packages/plugins/lists)                         | Bulleted, numbered, and todo lists    |
-| [@yoopta/blockquote](./packages/plugins/blockquote)               | Block quotes                          |
-| [@yoopta/callout](./packages/plugins/callout)                     | Callout/alert boxes with themes       |
-| [@yoopta/code](./packages/plugins/code)                           | Code blocks with syntax highlighting  |
-| [@yoopta/image](./packages/plugins/image)                         | Images with optimization              |
-| [@yoopta/video](./packages/plugins/video)                         | Video embeds (YouTube, Vimeo, etc.)   |
-| [@yoopta/embed](./packages/plugins/embed)                         | Generic embeds (Figma, Twitter, etc.) |
-| [@yoopta/file](./packages/plugins/file)                           | File attachments                      |
-| [@yoopta/table](./packages/plugins/table)                         | Tables with headers                   |
-| [@yoopta/accordion](./packages/plugins/accordion)                 | Collapsible accordion sections        |
-| [@yoopta/tabs](./packages/plugins/tabs)                           | Tabbed content panels                 |
-| [@yoopta/steps](./packages/plugins/steps)                         | Step-by-step instructions             |
-| [@yoopta/divider](./packages/plugins/divider)                     | Visual dividers                       |
-| [@yoopta/link](./packages/plugins/link)                           | Inline links                          |
-| [@yoopta/mention](./packages/plugins/mention)                     | @mentions                             |
-| [@yoopta/carousel](./packages/plugins/carousel)                   | Image carousels                       |
-| [@yoopta/table-of-contents](./packages/plugins/table-of-contents) | Table of contents block               |
+| Package                                                           | Description                                          |
+| ----------------------------------------------------------------- | ---------------------------------------------------- |
+| [@yoopta/paragraph](./packages/plugins/paragraph)                 | Basic text paragraph                                 |
+| [@yoopta/headings](./packages/plugins/headings)                   | H1, H2, H3 headings                                  |
+| [@yoopta/lists](./packages/plugins/lists)                         | Bulleted, numbered, and todo lists                   |
+| [@yoopta/blockquote](./packages/plugins/blockquote)               | Block quotes                                         |
+| [@yoopta/callout](./packages/plugins/callout)                     | Callout/alert boxes with themes                      |
+| [@yoopta/code](./packages/plugins/code)                           | Code blocks with syntax highlighting                 |
+| [@yoopta/image](./packages/plugins/image)                         | Images with optimization                             |
+| [@yoopta/video](./packages/plugins/video)                         | Video embeds (YouTube, Vimeo, etc.)                  |
+| [@yoopta/embed](./packages/plugins/embed)                         | Generic embeds (Figma, Twitter, etc.)                |
+| [@yoopta/file](./packages/plugins/file)                           | File attachments                                     |
+| [@yoopta/table](./packages/plugins/table)                         | Tables with headers                                  |
+| [@yoopta/accordion](./packages/plugins/accordion)                 | Collapsible accordion sections                       |
+| [@yoopta/tabs](./packages/plugins/tabs)                           | Tabbed content panels                                |
+| [@yoopta/steps](./packages/plugins/steps)                         | Step-by-step instructions                            |
+| [@yoopta/divider](./packages/plugins/divider)                     | Visual dividers                                      |
+| [@yoopta/link](./packages/plugins/link)                           | Inline links                                         |
+| [@yoopta/math](./packages/plugins/math)                           | Math expressions with KaTeX (MathInline + MathBlock) |
+| [@yoopta/mention](./packages/plugins/mention)                     | @mentions                                            |
+| [@yoopta/carousel](./packages/plugins/carousel)                   | Image carousels                                      |
+| [@yoopta/table-of-contents](./packages/plugins/table-of-contents) | Table of contents block                              |
 
 ### Marks (Text Formatting)
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -49,7 +49,10 @@ See what you can build with Yoopta:
   <Card title="Slack Chat" icon="comments" href="https://yoopta.dev/examples/slack-chat">
     Slack-style messaging with channel list, rich text composer, and mentions
   </Card>
-  <Card title="Social Media Chat" icon="message" href="https://yoopta.dev/examples/social-media-chat">
+  <Card
+    title="Social Media Chat"
+    icon="message"
+    href="https://yoopta.dev/examples/social-media-chat">
     WhatsApp/Instagram-like chat with message bubbles, attachments, and reactions
   </Card>
   <Card title="Collaboration" icon="users" href="https://yoopta.dev/examples/collaboration">
@@ -88,20 +91,21 @@ export default function Editor() {
 
 Install only what you need:
 
-| Category | Packages | Description |
-|----------|----------|-------------|
-| **Core** | `@yoopta/editor` | Headless editor engine (requires `slate`, `slate-react`, `slate-dom`) |
-| **UI** | `@yoopta/ui` | Toolbar, ActionMenuList, SlashCommandMenu, BlockOptions, FloatingBlockActions |
-| **Marks** | `@yoopta/marks` | Bold, Italic, Underline, Strike, Code, Highlight |
-| **Text** | `@yoopta/paragraph`, `@yoopta/headings`, `@yoopta/blockquote` | Basic text blocks |
-| **Lists** | `@yoopta/lists` | Bulleted, numbered, and todo lists |
-| **Media** | `@yoopta/image`, `@yoopta/video`, `@yoopta/file`, `@yoopta/embed` | Media and embed blocks |
-| **Layout** | `@yoopta/table`, `@yoopta/accordion`, `@yoopta/tabs`, `@yoopta/steps`, `@yoopta/carousel`, `@yoopta/callout`, `@yoopta/divider` | Structured layout blocks |
-| **Inline** | `@yoopta/link`, `@yoopta/mention`, `@yoopta/emoji` | Inline elements |
-| **Code** | `@yoopta/code` | Code block with syntax highlighting |
-| **Themes** | `@yoopta/themes-shadcn`, `@yoopta/themes-material` | Pre-styled plugin components |
-| **Exports** | `@yoopta/exports` | HTML, Markdown, plain text, email serializers |
-| **Collaboration** | `@yoopta/collaboration` | Real-time collaboration via Yjs |
+| Category          | Packages                                                                                                                        | Description                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Core**          | `@yoopta/editor`                                                                                                                | Headless editor engine (requires `slate`, `slate-react`, `slate-dom`)         |
+| **UI**            | `@yoopta/ui`                                                                                                                    | Toolbar, ActionMenuList, SlashCommandMenu, BlockOptions, FloatingBlockActions |
+| **Marks**         | `@yoopta/marks`                                                                                                                 | Bold, Italic, Underline, Strike, Code, Highlight                              |
+| **Text**          | `@yoopta/paragraph`, `@yoopta/headings`, `@yoopta/blockquote`                                                                   | Basic text blocks                                                             |
+| **Lists**         | `@yoopta/lists`                                                                                                                 | Bulleted, numbered, and todo lists                                            |
+| **Media**         | `@yoopta/image`, `@yoopta/video`, `@yoopta/file`, `@yoopta/embed`                                                               | Media and embed blocks                                                        |
+| **Layout**        | `@yoopta/table`, `@yoopta/accordion`, `@yoopta/tabs`, `@yoopta/steps`, `@yoopta/carousel`, `@yoopta/callout`, `@yoopta/divider` | Structured layout blocks                                                      |
+| **Inline**        | `@yoopta/link`, `@yoopta/mention`, `@yoopta/emoji`, `@yoopta/math`                                                              | Inline elements                                                               |
+| **Code**          | `@yoopta/code`                                                                                                                  | Code block with syntax highlighting                                           |
+| **Math**          | `@yoopta/math`                                                                                                                  | Code block with syntax highlighting                                           |
+| **Themes**        | `@yoopta/themes-shadcn`, `@yoopta/themes-material`                                                                              | Pre-styled plugin components                                                  |
+| **Exports**       | `@yoopta/exports`                                                                                                               | HTML, Markdown, plain text, email serializers                                 |
+| **Collaboration** | `@yoopta/collaboration`                                                                                                         | Real-time collaboration via Yjs                                               |
 
 ## Key Features
 
@@ -122,7 +126,8 @@ Install only what you need:
     Serialize to HTML, Markdown, plain text, or email-safe HTML out of the box.
   </Card>
   <Card title="Beyond Editing" icon="globe">
-    Build CMS dashboards, landing page builders, or full website builders — Yoopta provides the content primitives, you define the experience.
+    Build CMS dashboards, landing page builders, or full website builders — Yoopta provides the
+    content primitives, you define the experience.
   </Card>
   <Card title="TypeScript First" icon="code">
     Full type safety across the editor, plugins, and all APIs.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -80,6 +80,8 @@
         "plugins/image",
         "plugins/link",
         "plugins/lists",
+        "plugins/math",
+        "plugins/math-block",
         "plugins/mention",
         "plugins/paragraph",
         "plugins/steps",

--- a/docs/plugins/math-block.mdx
+++ b/docs/plugins/math-block.mdx
@@ -1,0 +1,201 @@
+---
+title: MathBlock
+description: Display-mode math equations as standalone blocks
+icon: 'square-root-variable'
+---
+
+import { PluginPlayground } from '../snippets/plugin-playground.jsx';
+
+## Overview
+
+The MathBlock plugin provides standalone, display-mode math equations rendered with [KaTeX](https://katex.org/). Unlike [MathInline](/plugins/math), which appears inline within text, MathBlock creates a dedicated block for larger equations that are centered and rendered in display mode.
+
+Both plugins are part of the `@yoopta/math` package, following the same pattern as `Code` / `CodeGroup` from `@yoopta/code`.
+
+<PluginPlayground pluginSlug="math-block" height={320} />
+
+## Installation
+
+```bash
+npm install @yoopta/math katex
+```
+
+You also need KaTeX CSS for proper rendering:
+
+```tsx
+import 'katex/dist/katex.min.css';
+```
+
+## Basic Usage
+
+Pass the plugin to `createYooptaEditor` (wrapped with `withMath`).
+
+```tsx
+import { useMemo } from 'react';
+import YooptaEditor, { createYooptaEditor } from '@yoopta/editor';
+import Paragraph from '@yoopta/paragraph';
+import { MathBlock, withMath } from '@yoopta/math';
+import 'katex/dist/katex.min.css';
+
+const plugins = [Paragraph, MathBlock];
+
+export default function Editor() {
+  const editor = useMemo(() => withMath(createYooptaEditor({ plugins, marks: [] })), []);
+
+  return <YooptaEditor editor={editor} placeholder="Type here..." />;
+}
+```
+
+To use both inline and block math together:
+
+```tsx
+import { MathInline, MathBlock, withMath } from '@yoopta/math';
+
+const plugins = [Paragraph, MathInline, MathBlock];
+```
+
+## Features
+
+- Display-mode equations rendered with KaTeX (centered, larger font)
+- Standalone block — not inline within text
+- Click to edit, with live KaTeX preview
+- Copy LaTeX source to clipboard
+- HTML, Markdown, and email serialization
+- Dark mode support
+
+## Using with Themes
+
+The `@yoopta/themes-shadcn` package includes a styled MathBlock component with a card-based edit UI.
+
+```tsx
+import { applyTheme } from '@yoopta/themes-shadcn';
+import { MathInline, MathBlock, withMath } from '@yoopta/math';
+import Paragraph from '@yoopta/paragraph';
+
+const plugins = applyTheme([Paragraph, MathInline, MathBlock]);
+
+const editor = withMath(createYooptaEditor({ plugins, marks: MARKS }));
+```
+
+The shadcn theme provides:
+
+- **Preview mode** — centered display-mode rendering with hover overlay (copy + edit buttons)
+- **Edit mode** — larger textarea with live preview, save/cancel/delete actions
+
+You can also apply the theme to just the MathBlock plugin:
+
+```tsx
+import { MathBlock } from '@yoopta/math';
+import { MathBlockUI } from '@yoopta/themes-shadcn/math';
+
+const StyledMathBlock = MathBlock.extend({ elements: MathBlockUI });
+```
+
+## Element Props
+
+| Prop       | Type     | Description                     |
+| ---------- | -------- | ------------------------------- |
+| `latex`    | `string` | The LaTeX expression string     |
+| `nodeType` | `string` | Always `'void'` for this plugin |
+
+## Commands
+
+Import commands: `import { MathBlockCommands } from '@yoopta/math'`
+
+### `buildMathBlockElement`
+
+Creates a math block element structure without inserting it.
+
+```tsx
+const element = MathBlockCommands.buildMathBlockElement(editor, {
+  props: { latex: '\\int_0^\\infty e^{-x} dx = 1' },
+});
+```
+
+### `updateMathBlock`
+
+Updates the LaTeX expression of an existing math block.
+
+```tsx
+MathBlockCommands.updateMathBlock(editor, blockId, '\\sum_{n=1}^{\\infty} \\frac{1}{n^2} = \\frac{\\pi^2}{6}');
+```
+
+### `getMathBlockElement`
+
+Finds the math-block element in a given block.
+
+```tsx
+const element = MathBlockCommands.getMathBlockElement(editor, {
+  blockId: 'block-1',
+});
+```
+
+### `openEditor` / `closeEditor`
+
+Controls the edit state (requires `withMath` extension). Shared with MathInline.
+
+```tsx
+MathBlockCommands.openEditor(editor, {
+  element: mathBlockElement,
+  blockId: 'block-1',
+  anchorEl: domNode,
+});
+
+MathBlockCommands.closeEditor(editor);
+```
+
+## Editor Extension
+
+MathBlock shares the same `withMath` extension as MathInline. See the [MathInline docs](/plugins/math#editor-extension) for details.
+
+```tsx
+import { withMath } from '@yoopta/math';
+
+const editor = withMath(createYooptaEditor({ plugins, marks }));
+```
+
+## Parsers
+
+### HTML
+
+Serializes to `<div data-math-block data-latex="...">` with KaTeX-rendered content inside (display mode).
+
+Deserializes from `<div data-math-block>` elements, reading the `data-latex` attribute.
+
+### Markdown
+
+Serializes to block math syntax:
+
+```
+$$
+E = mc^2
+$$
+```
+
+### Email
+
+Serializes with display-mode KaTeX HTML output wrapped in a centered div for email clients.
+
+## LaTeX Examples
+
+Common display-mode expressions:
+
+| Expression         | LaTeX                                                              |
+| ------------------ | ------------------------------------------------------------------ |
+| Integral           | `\int_0^\infty e^{-x} dx = 1`                                     |
+| Summation          | `\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}`            |
+| Matrix             | `\begin{pmatrix} a & b \\ c & d \end{pmatrix}`                    |
+| Aligned equations  | `\begin{aligned} x &= a + b \\ y &= c + d \end{aligned}`         |
+| Limit              | `\lim_{x \to \infty} \frac{1}{x} = 0`                             |
+| Binomial           | `\binom{n}{k} = \frac{n!}{k!(n-k)!}`                              |
+
+## Related Plugins
+
+<CardGroup cols={2}>
+  <Card title="MathInline" icon="sigma" href="/plugins/math">
+    Inline math expressions within text
+  </Card>
+  <Card title="Code" icon="code" href="/plugins/code">
+    Code blocks (another void block plugin)
+  </Card>
+</CardGroup>

--- a/docs/plugins/math.mdx
+++ b/docs/plugins/math.mdx
@@ -1,0 +1,283 @@
+---
+title: MathInline
+description: Inline math expressions rendered with KaTeX
+icon: 'sigma'
+---
+
+import { PluginPlayground } from '../snippets/plugin-playground.jsx';
+
+## Overview
+
+The MathInline plugin enables users to insert inline math expressions into any text block. Expressions are written in LaTeX and rendered using [KaTeX](https://katex.org/). It works as an `inlineVoid` element, meaning it appears inline alongside regular text but is not directly editable — users edit the LaTeX source through a popover.
+
+Part of the `@yoopta/math` package, which also includes the [MathBlock](/plugins/math-block) plugin for standalone display-mode equations.
+
+<PluginPlayground pluginSlug="math" height={320} />
+
+## Installation
+
+```bash
+npm install @yoopta/math katex
+```
+
+You also need KaTeX CSS for proper rendering:
+
+```tsx
+import 'katex/dist/katex.min.css';
+```
+
+## Basic Usage
+
+Pass the plugin to `createYooptaEditor` (wrapped with `withMath`). Plugins and marks are passed to `createYooptaEditor`, not to `<YooptaEditor>`.
+
+```tsx
+import { useMemo } from 'react';
+import YooptaEditor, { createYooptaEditor } from '@yoopta/editor';
+import Paragraph from '@yoopta/paragraph';
+import { MathInline, withMath } from '@yoopta/math';
+import 'katex/dist/katex.min.css';
+
+const plugins = [Paragraph, MathInline];
+
+export default function Editor() {
+  const editor = useMemo(() => withMath(createYooptaEditor({ plugins, marks: [] })), []);
+
+  return <YooptaEditor editor={editor} placeholder="Type here..." />;
+}
+```
+
+To use both inline and block math together:
+
+```tsx
+import { MathInline, MathBlock, withMath } from '@yoopta/math';
+
+const plugins = [Paragraph, MathInline, MathBlock];
+```
+
+## Features
+
+- Inline math expressions rendered with KaTeX
+- Works inside any text block (Paragraph, Headings, Callout, Lists, etc.)
+- Live preview while editing LaTeX source
+- Copy LaTeX source to clipboard
+- Toolbar integration — select text and convert to math expression
+- HTML, Markdown, and email serialization
+- Dark mode support
+
+## Using with Themes
+
+The `@yoopta/themes-shadcn` package includes a styled MathInline component with a HoverCard for preview and editing.
+
+```tsx
+import { applyTheme } from '@yoopta/themes-shadcn';
+import { MathInline, MathBlock, withMath } from '@yoopta/math';
+import Paragraph from '@yoopta/paragraph';
+
+const plugins = applyTheme([Paragraph, MathInline, MathBlock]);
+
+const editor = withMath(createYooptaEditor({ plugins, marks: MARKS }));
+```
+
+The shadcn theme provides:
+
+- **Preview mode** — rendered math, LaTeX source display, copy and edit buttons
+- **Edit mode** — live preview, LaTeX textarea input, save/cancel/delete actions
+
+You can also apply the theme to just the MathInline plugin:
+
+```tsx
+import { MathInline } from '@yoopta/math';
+import { MathInlineUI } from '@yoopta/themes-shadcn/math';
+
+const StyledMathInline = MathInline.extend({ elements: MathInlineUI });
+```
+
+## Element Props
+
+| Prop       | Type     | Description                           |
+| ---------- | -------- | ------------------------------------- |
+| `latex`    | `string` | The LaTeX expression string           |
+| `nodeType` | `string` | Always `'inlineVoid'` for this plugin |
+
+## Commands
+
+Import commands: `import { MathInlineCommands } from '@yoopta/math'`
+
+### `buildMathInlineElement`
+
+Creates a math inline element structure without inserting it.
+
+```tsx
+const element = MathInlineCommands.buildMathInlineElement(editor, {
+  props: { latex: 'x^2 + y^2 = r^2' },
+});
+```
+
+### `insertMathInline`
+
+Inserts a math inline element at the current Slate selection.
+
+```tsx
+import { Blocks } from '@yoopta/editor';
+
+const slate = Blocks.getBlockSlate(editor, { id: blockId });
+MathInlineCommands.insertMathInline(editor, 'E = mc^2', { slate });
+```
+
+If text is selected, the selection is replaced with the math element.
+
+### `updateMathInline`
+
+Updates the LaTeX expression of an existing math element.
+
+```tsx
+MathInlineCommands.updateMathInline(editor, elementId, '\\frac{a}{b}', {
+  blockId: 'block-1',
+});
+```
+
+### `deleteMathInline`
+
+Removes a math inline element by its ID.
+
+```tsx
+MathInlineCommands.deleteMathInline(editor, elementId, {
+  blockId: 'block-1',
+});
+```
+
+### `findMathInlineElements`
+
+Finds all math inline elements in a block.
+
+```tsx
+const elements = MathInlineCommands.findMathInlineElements(editor, {
+  blockId: 'block-1',
+});
+```
+
+### `openEditor` / `closeEditor`
+
+Controls the edit popover state (requires `withMath` extension).
+
+```tsx
+MathInlineCommands.openEditor(editor, {
+  element: mathElement,
+  blockId: 'block-1',
+  anchorEl: domNode,
+});
+
+MathInlineCommands.closeEditor(editor);
+```
+
+## Editor Extension
+
+The `withMath` function extends the editor with a `math` namespace for managing the edit popover state. This extension is shared between MathInline and MathBlock.
+
+```tsx
+import { withMath } from '@yoopta/math';
+
+const editor = withMath(createYooptaEditor({ plugins, marks }));
+
+// Access state
+editor.math.state; // { isOpen, editingElement, blockId, anchorEl }
+
+// Open/close programmatically
+editor.math.open({ element, blockId, anchorEl });
+editor.math.close();
+```
+
+### `useMathState` Hook
+
+Subscribe to math state changes in React components (must be inside `<YooptaEditor>`).
+
+```tsx
+import { useMathState } from '@yoopta/math';
+
+function MyComponent() {
+  const { isOpen, editingElement, blockId } = useMathState();
+  // ...
+}
+```
+
+## Toolbar Integration
+
+Add a math button to the floating toolbar that converts selected text into a math expression:
+
+```tsx
+import { Blocks, useYooptaEditor } from '@yoopta/editor';
+import { MathInlineCommands } from '@yoopta/math';
+import { Editor, Range } from 'slate';
+import { SigmaIcon } from 'lucide-react';
+
+function MathToolbarButton() {
+  const editor = useYooptaEditor();
+
+  const onInsertMath = () => {
+    if (editor.path.current === null) return;
+
+    const currentBlockId = Object.keys(editor.children).find(
+      (id) => editor.children[id]?.meta.order === editor.path.current,
+    );
+    if (!currentBlockId) return;
+
+    const slate = Blocks.getBlockSlate(editor, { id: currentBlockId });
+    if (!slate || !slate.selection) return;
+
+    // Use selected text as LaTeX, or fall back to placeholder
+    const selectedText = !Range.isCollapsed(slate.selection)
+      ? Editor.string(slate, slate.selection)
+      : '';
+
+    MathInlineCommands.insertMathInline(editor, selectedText || 'E = mc^2', { slate });
+  };
+
+  return (
+    <button onClick={onInsertMath} title="Insert Math">
+      <SigmaIcon />
+    </button>
+  );
+}
+```
+
+## Parsers
+
+### HTML
+
+Serializes to `<span data-math-inline data-latex="...">` with KaTeX-rendered content inside.
+
+Deserializes from `<span data-math-inline>` elements, reading the `data-latex` attribute.
+
+### Markdown
+
+Serializes to standard inline math syntax: `$E = mc^2$`
+
+### Email
+
+Serializes with KaTeX HTML output wrapped in a serif font span for email clients.
+
+## LaTeX Examples
+
+Common expressions to use with the plugin:
+
+| Expression    | LaTeX                                          |
+| ------------- | ---------------------------------------------- |
+| Fraction      | `\frac{a}{b}`                                  |
+| Square root   | `\sqrt{x}`                                     |
+| Superscript   | `x^2`                                          |
+| Subscript     | `x_i`                                          |
+| Summation     | `\sum_{i=1}^{n} x_i`                           |
+| Integral      | `\int_0^1 f(x) dx`                             |
+| Greek letters | `\alpha, \beta, \gamma`                        |
+| Matrix        | `\begin{pmatrix} a & b \\ c & d \end{pmatrix}` |
+
+## Related Plugins
+
+<CardGroup cols={2}>
+  <Card title="MathBlock" icon="square-root-variable" href="/plugins/math-block">
+    Display-mode math equations as standalone blocks
+  </Card>
+  <Card title="Mention" icon="at-sign" href="/plugins/mention">
+    @mentions (another inlineVoid element plugin)
+  </Card>
+</CardGroup>

--- a/packages/core/editor/src/plugins/build-plugin-elements.ts
+++ b/packages/core/editor/src/plugins/build-plugin-elements.ts
@@ -21,7 +21,7 @@ export type PluginJSXElement = ReactElement<PluginJSXElementProps, string>;
 
 function buildElementsMap<TKeys extends string = string>(
   jsxElement: PluginJSXElement,
-  pluginType: string,
+  pluginType?: string,
 ): PluginElementsMap<TKeys> {
   const elementsMap: PluginElementsMap<TKeys> = {} as PluginElementsMap<TKeys>;
 
@@ -65,15 +65,15 @@ function buildElementsMap<TKeys extends string = string>(
     if (children) {
       const childrenArray: PluginJSXElement[] = Array.isArray(children)
         ? children.filter(
-            (child): child is PluginJSXElement =>
-              typeof child === 'object' && child !== null && 'type' in child && 'props' in child,
-          )
+          (child): child is PluginJSXElement =>
+            typeof child === 'object' && child !== null && 'type' in child && 'props' in child,
+        )
         : typeof children === 'object' &&
           children !== null &&
           'type' in children &&
           'props' in children
-        ? [children as PluginJSXElement]
-        : [];
+          ? [children as PluginJSXElement]
+          : [];
 
       if (childrenArray.length > 0) {
         const childTypes = childrenArray.map((child) => traverse(child, false));
@@ -92,7 +92,7 @@ function buildElementsMap<TKeys extends string = string>(
 
 export function buildPluginElements<TKeys extends string = string>(
   jsxElement: PluginJSXElement,
-  pluginType: string,
+  pluginType?: string,
 ): PluginElementsMap<TKeys> {
   const elementsMap = buildElementsMap<TKeys>(jsxElement, pluginType);
   return elementsMap;

--- a/packages/plugins/math/package.json
+++ b/packages/plugins/math/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@yoopta/math",
+  "version": "6.0.2",
+  "description": "Inline math (KaTeX) plugin for Yoopta Editor",
+  "author": "Darginec05 <devopsbanda@gmail.com>",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "type": "module",
+  "module": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
+  "dependencies": {
+    "katex": "^0.16.11"
+  },
+  "peerDependencies": {
+    "@yoopta/editor": "6.0.2",
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
+  },
+  "scripts": {
+    "test": "echo \"No tests yet\"",
+    "start": "rollup --config rollup.config.js --watch --bundleConfigAsCjs --environment NODE_ENV:development",
+    "prepublishOnly": "yarn build",
+    "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
+  },
+  "bugs": {
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
+  }
+}

--- a/packages/plugins/math/rollup.config.js
+++ b/packages/plugins/math/rollup.config.js
@@ -1,0 +1,5 @@
+import { createRollupConfig } from '../../../config/rollup';
+
+const pkg = require('./package.json');
+
+export default createRollupConfig({ pkg });

--- a/packages/plugins/math/src/commands/math-block-commands.ts
+++ b/packages/plugins/math/src/commands/math-block-commands.ts
@@ -1,0 +1,104 @@
+import type { YooEditor, YooptaPathIndex } from '@yoopta/editor';
+import { Blocks, Elements, generateId } from '@yoopta/editor';
+import { Editor, Element, Transforms } from 'slate';
+
+import type { MathBlockElement, MathYooEditor } from '../types';
+
+function getMathEditor(editor: YooEditor): MathYooEditor {
+  return editor as MathYooEditor;
+}
+
+type FindOptions = {
+  blockId?: string;
+  at?: YooptaPathIndex;
+};
+
+export type MathBlockCommandsType = {
+  buildMathBlockElement: (
+    editor: YooEditor,
+    options: { props: { latex: string } },
+  ) => MathBlockElement;
+  updateMathBlock: (editor: YooEditor, blockId: string, latex: string) => void;
+  getMathBlockElement: (editor: YooEditor, options?: FindOptions) => MathBlockElement | null;
+  openEditor: (
+    editor: YooEditor,
+    params: {
+      element?: MathBlockElement | null;
+      blockId: string | null;
+      anchorEl: HTMLElement | null;
+    },
+  ) => void;
+  closeEditor: (editor: YooEditor) => void;
+};
+
+export const MathBlockCommands: MathBlockCommandsType = {
+  buildMathBlockElement: (_editor, options) => ({
+    id: generateId(),
+    type: 'math-block',
+    children: [{ text: '' }],
+    props: {
+      latex: options.props.latex,
+      nodeType: 'void',
+    },
+  } as MathBlockElement),
+
+  updateMathBlock: (editor, blockId, latex) => {
+    const slateEditor = Blocks.getBlockSlate(editor, { id: blockId });
+    if (!slateEditor) return;
+
+    const entries = Array.from(
+      Editor.nodes(slateEditor, {
+        at: [],
+        match: (n): n is MathBlockElement =>
+          Element.isElement(n) && !Editor.isEditor(n) && n.type === 'math-block',
+      }),
+    );
+
+    const firstEntry = entries[0];
+    if (firstEntry) {
+      const [node, path] = firstEntry;
+      Transforms.setNodes(
+        slateEditor,
+        {
+          props: {
+            ...node.props,
+            latex,
+            nodeType: 'void',
+          },
+        } as Partial<MathBlockElement>,
+        { at: path },
+      );
+    }
+  },
+
+  getMathBlockElement: (editor, options = {}) => {
+    try {
+      const blockToFind = options.blockId
+        ? { id: options.blockId }
+        : { at: options.at ?? editor.path.current };
+
+      const slateEditor = Blocks.getBlockSlate(editor, blockToFind);
+      if (!slateEditor) return null;
+
+      for (const [node] of Editor.nodes(slateEditor, {
+        at: [],
+        match: (n): n is MathBlockElement =>
+          Element.isElement(n) && !Editor.isEditor(n) && n.type === 'math-block',
+      })) {
+        return node;
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  },
+
+  openEditor: (editor, params) => {
+    getMathEditor(editor).math.open(params);
+  },
+
+  closeEditor: (editor) => {
+    getMathEditor(editor).math.close();
+  },
+};

--- a/packages/plugins/math/src/commands/math-inline-commands.ts
+++ b/packages/plugins/math/src/commands/math-inline-commands.ts
@@ -1,0 +1,176 @@
+import type { SlateEditor, YooEditor, YooptaPathIndex } from '@yoopta/editor';
+import { Blocks, generateId } from '@yoopta/editor';
+import { Editor, Element, Range, Transforms } from 'slate';
+
+import type { MathInlineElement, MathYooEditor } from '../types';
+
+function getMathEditor(editor: YooEditor): MathYooEditor {
+  return editor as MathYooEditor;
+}
+
+type BuildOptions = {
+  props: { latex: string };
+};
+
+type InsertOptions = {
+  slate: SlateEditor;
+  focus?: boolean;
+};
+
+type FindOptions = {
+  blockId?: string;
+  at?: YooptaPathIndex;
+};
+
+export type MathInlineCommandsType = {
+  buildMathInlineElement: (editor: YooEditor, options: BuildOptions) => MathInlineElement;
+  insertMathInline: (editor: YooEditor, latex: string, options: InsertOptions) => void;
+  findMathInlineElements: (editor: YooEditor, options?: FindOptions) => MathInlineElement[];
+  updateMathInline: (
+    editor: YooEditor,
+    elementId: string,
+    latex: string,
+    options?: FindOptions,
+  ) => void;
+  deleteMathInline: (editor: YooEditor, elementId: string, options?: FindOptions) => void;
+  openEditor: (
+    editor: YooEditor,
+    params: {
+      element?: MathInlineElement | null;
+      blockId: string | null;
+      anchorEl: HTMLElement | null;
+    },
+  ) => void;
+  closeEditor: (editor: YooEditor) => void;
+};
+
+export const MathInlineCommands: MathInlineCommandsType = {
+  buildMathInlineElement: (_editor, options) => ({
+    id: generateId(),
+    type: 'math-inline',
+    children: [{ text: '' }],
+    props: {
+      latex: options.props.latex,
+      nodeType: 'inlineVoid',
+    },
+  } as MathInlineElement),
+
+  insertMathInline: (editor, latex, options) => {
+    const { slate } = options;
+    if (!slate || !slate.selection) return;
+
+    if (!Range.isCollapsed(slate.selection)) {
+      Transforms.delete(slate);
+    }
+
+    const mathNode: MathInlineElement = {
+      id: generateId(),
+      type: 'math-inline',
+      children: [{ text: '' }],
+      props: {
+        latex,
+        nodeType: 'inlineVoid',
+      },
+    };
+
+    Transforms.insertNodes(slate, mathNode);
+    Transforms.move(slate, { distance: 1 });
+
+    if (options.focus) {
+      const blockId = Object.keys(editor.children).find((id) => {
+        const block = editor.children[id];
+        return block?.meta.order === editor.path.current;
+      });
+      if (blockId) editor.focusBlock(blockId);
+    }
+  },
+
+  findMathInlineElements: (editor, options = {}) => {
+    try {
+      const blockToFind = options.blockId
+        ? { id: options.blockId }
+        : { at: options.at ?? editor.path.current };
+
+      const slateEditor = Blocks.getBlockSlate(editor, blockToFind);
+      if (!slateEditor) return [];
+
+      const elements: MathInlineElement[] = [];
+
+      for (const [node] of Editor.nodes(slateEditor, {
+        at: [],
+        match: (n): n is MathInlineElement =>
+          Element.isElement(n) && !Editor.isEditor(n) && n.type === 'math-inline',
+      })) {
+        elements.push(node);
+      }
+
+      return elements;
+    } catch {
+      return [];
+    }
+  },
+
+  updateMathInline: (editor, elementId, latex, options = {}) => {
+    const blockToFind = options.blockId
+      ? { id: options.blockId }
+      : { at: options.at ?? editor.path.current };
+
+    const slateEditor = Blocks.getBlockSlate(editor, blockToFind);
+    if (!slateEditor) return;
+
+    const entries = Array.from(
+      Editor.nodes(slateEditor, {
+        at: [],
+        match: (n): n is MathInlineElement =>
+          Element.isElement(n) && !Editor.isEditor(n) && n.type === 'math-inline' && n.id === elementId,
+      }),
+    );
+
+    const firstEntry = entries[0];
+    if (firstEntry) {
+      const [node, path] = firstEntry;
+      Transforms.setNodes(
+        slateEditor,
+        {
+          props: {
+            ...node.props,
+            latex,
+            nodeType: 'inlineVoid',
+          },
+        } as Partial<MathInlineElement>,
+        { at: path },
+      );
+    }
+  },
+
+  deleteMathInline: (editor, elementId, options = {}) => {
+    const blockToFind = options.blockId
+      ? { id: options.blockId }
+      : { at: options.at ?? editor.path.current };
+
+    const slateEditor = Blocks.getBlockSlate(editor, blockToFind);
+    if (!slateEditor) return;
+
+    const entries = Array.from(
+      Editor.nodes(slateEditor, {
+        at: [],
+        match: (n): n is MathInlineElement =>
+          Element.isElement(n) && !Editor.isEditor(n) && n.type === 'math-inline' && n.id === elementId,
+      }),
+    );
+
+    const firstEntry = entries[0];
+    if (firstEntry) {
+      const [, path] = firstEntry;
+      Transforms.removeNodes(slateEditor, { at: path });
+    }
+  },
+
+  openEditor: (editor, params) => {
+    getMathEditor(editor).math.open(params);
+  },
+
+  closeEditor: (editor) => {
+    getMathEditor(editor).math.close();
+  },
+};

--- a/packages/plugins/math/src/extensions/withMath.ts
+++ b/packages/plugins/math/src/extensions/withMath.ts
@@ -1,0 +1,46 @@
+import type { YooEditor } from '@yoopta/editor';
+
+import type { MathBlockElement, MathInlineElement, MathState, MathYooEditor } from '../types';
+import { INITIAL_MATH_STATE } from '../types';
+
+type MathEmit = (event: string, payload: unknown) => void;
+
+export function withMath(editor: YooEditor): MathYooEditor {
+  const mathEditor = editor as MathYooEditor;
+
+  let state: MathState = { ...INITIAL_MATH_STATE };
+
+  const emit = editor.emit as MathEmit;
+
+  mathEditor.math = {
+    get state() {
+      return state;
+    },
+    setState: (newState: Partial<MathState>) => {
+      state = { ...state, ...newState };
+    },
+    open: (params: {
+      element?: (MathInlineElement | MathBlockElement) | null;
+      blockId: string | null;
+      anchorEl: HTMLElement | null;
+    }) => {
+      state = {
+        isOpen: true,
+        editingElement: params.element ?? null,
+        blockId: params.blockId ?? null,
+        anchorEl: params.anchorEl ?? null,
+      };
+
+      emit('math:open', {
+        element: params.element,
+        blockId: params.blockId,
+      });
+    },
+    close: () => {
+      state = { ...INITIAL_MATH_STATE };
+      emit('math:close', {});
+    },
+  };
+
+  return mathEditor;
+}

--- a/packages/plugins/math/src/hooks/index.ts
+++ b/packages/plugins/math/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useMathState } from './use-math-state';

--- a/packages/plugins/math/src/hooks/use-math-state.ts
+++ b/packages/plugins/math/src/hooks/use-math-state.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useYooptaEditor } from '@yoopta/editor';
+
+import type { MathState, MathYooEditor } from '../types';
+import { INITIAL_MATH_STATE } from '../types';
+
+/**
+ * Hook to subscribe to math editor extension state changes.
+ * Returns the current state of the math inline edit popover.
+ */
+export function useMathState(): MathState {
+  const editor = useYooptaEditor() as MathYooEditor;
+  const [state, setState] = useState<MathState>(
+    () => editor.math?.state ?? INITIAL_MATH_STATE,
+  );
+
+  useEffect(() => {
+    const onOpen = () => {
+      setState({ ...editor.math.state });
+    };
+
+    const onClose = () => {
+      setState({ ...INITIAL_MATH_STATE });
+    };
+
+    editor.on('math:open', onOpen);
+    editor.on('math:close', onClose);
+
+    return () => {
+      editor.off('math:open', onOpen);
+      editor.off('math:close', onClose);
+    };
+  }, [editor]);
+
+  return state;
+}

--- a/packages/plugins/math/src/index.ts
+++ b/packages/plugins/math/src/index.ts
@@ -1,0 +1,54 @@
+import { MathInline } from './plugin/math-inline-plugin';
+import { MathBlock } from './plugin/math-block-plugin';
+
+// --- MathInline types ---
+export type {
+  MathInlineElementProps,
+  MathInlineElement,
+  MathInlineElementMap,
+  MathInlinePluginElementKeys,
+} from './types';
+
+// --- MathBlock types ---
+export type {
+  MathBlockElementProps,
+  MathBlockElement,
+  MathBlockElementMap,
+  MathBlockPluginElementKeys,
+} from './types';
+
+// --- Shared types ---
+export type {
+  MathState,
+  MathPluginOptions,
+  MathEditor,
+  MathYooEditor,
+} from './types';
+
+export { INITIAL_MATH_STATE } from './types';
+
+// --- Commands ---
+export { MathInlineCommands } from './commands/math-inline-commands';
+export type { MathInlineCommandsType } from './commands/math-inline-commands';
+
+export { MathBlockCommands } from './commands/math-block-commands';
+export type { MathBlockCommandsType } from './commands/math-block-commands';
+
+// --- Hooks ---
+export { useMathState } from './hooks';
+
+// --- Extension ---
+export { withMath } from './extensions/withMath';
+
+// --- Utils ---
+export { renderLatexToHTML } from './utils';
+
+// --- Plugins ---
+export { MathInline, MathBlock };
+
+const Math = {
+  MathInline,
+  MathBlock,
+};
+
+export default Math;

--- a/packages/plugins/math/src/plugin/math-block-plugin.tsx
+++ b/packages/plugins/math/src/plugin/math-block-plugin.tsx
@@ -1,0 +1,107 @@
+import type { PluginElementRenderProps } from '@yoopta/editor';
+import { YooptaPlugin, generateId, useYooptaEditor } from '@yoopta/editor';
+
+import { MathBlockCommands } from '../commands/math-block-commands';
+import type { MathBlockElementMap, MathBlockElementProps, MathYooEditor } from '../types';
+import { renderLatexToHTML } from '../utils';
+
+const DefaultMathBlockRender = (props: PluginElementRenderProps) => {
+  const { element, attributes, children } = props;
+  const editor = useYooptaEditor() as MathYooEditor;
+  const { latex } = element.props as MathBlockElementProps;
+
+  const html = renderLatexToHTML(latex || '\\text{Enter math expression...}', true);
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (editor?.math) {
+      editor.math.open({
+        element: element as any,
+        blockId: props.blockId,
+        anchorEl: e.currentTarget,
+      });
+    }
+  };
+
+  return (
+    <div
+      {...attributes}
+      contentEditable={false}
+      data-math-block
+      data-latex={latex}
+      onClick={handleClick}
+      style={{
+        padding: '1em 0',
+        textAlign: 'center',
+        cursor: 'pointer',
+        minHeight: '3em',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <span dangerouslySetInnerHTML={{ __html: html }} />
+      {children}
+    </div>
+  );
+};
+
+const defaultMathBlockProps: MathBlockElementProps = {
+  latex: '',
+  nodeType: 'void',
+};
+
+const MathBlock = new YooptaPlugin<MathBlockElementMap>({
+  type: 'MathBlock',
+  elements: (
+    <math-block
+      render={DefaultMathBlockRender}
+      props={defaultMathBlockProps}
+      nodeType="void"
+    />
+  ),
+  options: {
+    display: {
+      title: 'Math (Block)',
+      description: 'Insert a display math equation',
+    },
+  },
+  commands: MathBlockCommands,
+  parsers: {
+    html: {
+      deserialize: {
+        nodeNames: ['DIV'],
+        parse: (el) => {
+          if (el.nodeName === 'DIV' && el.hasAttribute('data-math-block')) {
+            const latex = el.getAttribute('data-latex') ?? '';
+            return {
+              id: generateId(),
+              type: 'math-block',
+              children: [{ text: '' }],
+              props: {
+                latex,
+                nodeType: 'void',
+              },
+            };
+          }
+        },
+      },
+      serialize: (element) => {
+        const { latex } = element.props ?? {};
+        const html = renderLatexToHTML(latex || '', true);
+        return `<div data-math-block data-latex="${encodeURIComponent(latex || '')}" style="text-align:center;padding:1em 0;">${html}</div>`;
+      },
+    },
+    markdown: {
+      serialize: (element) => `$$\n${element.props?.latex ?? ''}\n$$`,
+    },
+    email: {
+      serialize: (element) => {
+        const { latex } = element.props ?? {};
+        const html = renderLatexToHTML(latex || '', true);
+        return `<div style="text-align:center;padding:1em 0;font-family:'Times New Roman',serif;">${html}</div>`;
+      },
+    },
+  },
+});
+
+export { MathBlock };

--- a/packages/plugins/math/src/plugin/math-inline-plugin.tsx
+++ b/packages/plugins/math/src/plugin/math-inline-plugin.tsx
@@ -1,0 +1,108 @@
+import type { PluginElementRenderProps } from '@yoopta/editor';
+import { YooptaPlugin, generateId, useYooptaEditor } from '@yoopta/editor';
+
+import { MathInlineCommands } from '../commands/math-inline-commands';
+import type { MathInlineElementMap, MathInlineElementProps, MathYooEditor } from '../types';
+import { renderLatexToHTML } from '../utils';
+
+const DefaultMathInlineRender = (props: PluginElementRenderProps) => {
+  const { element, attributes, children } = props;
+  const editor = useYooptaEditor() as MathYooEditor;
+  const { latex } = element.props as MathInlineElementProps;
+
+  const html = renderLatexToHTML(latex || '\\text{math}');
+
+  const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+    if (editor?.math) {
+      editor.math.open({
+        element: element as any,
+        blockId: props.blockId,
+        anchorEl: e.currentTarget,
+      });
+    }
+  };
+
+  return (
+    <span
+      {...attributes}
+      contentEditable={false}
+      data-math-inline
+      data-latex={latex}
+      onClick={handleClick}
+      style={{ cursor: 'pointer' }}
+    >
+      <span dangerouslySetInnerHTML={{ __html: html }} />
+      {children}
+    </span>
+  );
+};
+
+const defaultMathInlineProps: MathInlineElementProps = {
+  latex: '',
+  nodeType: 'inlineVoid',
+};
+
+const MathInline = new YooptaPlugin<MathInlineElementMap>({
+  type: 'MathInline',
+  elements: (
+    <math-inline
+      render={DefaultMathInlineRender}
+      props={defaultMathInlineProps}
+      nodeType="inlineVoid"
+    />
+  ),
+  options: {
+    display: {
+      title: 'Math (Inline)',
+      description: 'Insert an inline math expression',
+    },
+  },
+  commands: MathInlineCommands,
+  parsers: {
+    html: {
+      deserialize: {
+        nodeNames: ['SPAN'],
+        parse: (el) => {
+          if (el.nodeName === 'SPAN' && el.hasAttribute('data-math-inline')) {
+            const latex = el.getAttribute('data-latex') ?? '';
+            return {
+              id: generateId(),
+              type: 'math-inline',
+              children: [{ text: '' }],
+              props: {
+                latex,
+                nodeType: 'inlineVoid',
+              },
+            };
+          }
+        },
+      },
+      serialize: (element) => {
+        const { latex } = element.props ?? {};
+        const html = renderLatexToHTML(latex || '');
+        return `<span data-math-inline data-latex="${encodeURIComponent(latex || '')}">${html}</span>`;
+      },
+    },
+    markdown: {
+      serialize: (element) => `$${element.props?.latex ?? ''}$`,
+    },
+    email: {
+      serialize: (element) => {
+        const { latex } = element.props ?? {};
+        const html = renderLatexToHTML(latex || '');
+        return `<span style="font-family: 'Times New Roman', serif;">${html}</span>`;
+      },
+    },
+  },
+  extensions: (slate) => {
+    const { isVoid, isInline, markableVoid } = slate;
+
+    slate.isVoid = (element) => element.type === 'math-inline' || isVoid(element);
+    slate.isInline = (element) => element.type === 'math-inline' || isInline(element);
+    slate.markableVoid = (element) => element.type === 'math-inline' || markableVoid(element);
+
+    return slate;
+  },
+});
+
+export { MathInline };

--- a/packages/plugins/math/src/types.ts
+++ b/packages/plugins/math/src/types.ts
@@ -1,0 +1,67 @@
+import type { SlateElement, YooEditor } from '@yoopta/editor';
+
+// --- MathInline (inlineVoid) ---
+
+export type MathInlinePluginElementKeys = 'math-inline';
+
+export type MathInlineElementProps = {
+  latex: string;
+  nodeType: 'inlineVoid';
+};
+
+export type MathInlineElement = SlateElement<'math-inline', MathInlineElementProps>;
+
+export type MathInlineElementMap = {
+  'math-inline': MathInlineElement;
+};
+
+// --- MathBlock (void block) ---
+
+export type MathBlockPluginElementKeys = 'math-block';
+
+export type MathBlockElementProps = {
+  latex: string;
+  nodeType: 'void';
+};
+
+export type MathBlockElement = SlateElement<'math-block', MathBlockElementProps>;
+
+export type MathBlockElementMap = {
+  'math-block': MathBlockElement;
+};
+
+// --- Shared editor extension state ---
+
+export type MathState = {
+  isOpen: boolean;
+  editingElement: (MathInlineElement | MathBlockElement) | null;
+  blockId: string | null;
+  anchorEl: HTMLElement | null;
+};
+
+export const INITIAL_MATH_STATE: MathState = {
+  isOpen: false,
+  editingElement: null,
+  blockId: null,
+  anchorEl: null,
+};
+
+export type MathPluginOptions = {
+  onInsert?: (latex: string) => void;
+  onUpdate?: (latex: string) => void;
+};
+
+export type MathEditor = {
+  math: {
+    state: MathState;
+    setState: (state: Partial<MathState>) => void;
+    open: (params: {
+      element?: (MathInlineElement | MathBlockElement) | null;
+      blockId: string | null;
+      anchorEl: HTMLElement | null;
+    }) => void;
+    close: () => void;
+  };
+};
+
+export type MathYooEditor = YooEditor & MathEditor;

--- a/packages/plugins/math/src/utils/index.ts
+++ b/packages/plugins/math/src/utils/index.ts
@@ -1,0 +1,17 @@
+import katex from 'katex';
+
+/**
+ * Renders a LaTeX string to HTML using KaTeX.
+ * Returns an error message HTML if the expression is invalid.
+ */
+export function renderLatexToHTML(latex: string, displayMode = false): string {
+  try {
+    return katex.renderToString(latex, {
+      throwOnError: false,
+      displayMode,
+      output: 'htmlAndMathml',
+    });
+  } catch {
+    return `<span style="color: red;">Invalid LaTeX</span>`;
+  }
+}

--- a/packages/plugins/math/tsconfig.json
+++ b/packages/plugins/math/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../config/tsconfig.base.json",
+  "include": ["react-svg.d.ts", "css-modules.d.ts", "src", "../../core/editor/src/slate.d.ts", "../../core/editor/src/jsx.d.ts"],
+  "exclude": ["dist", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "references": [
+    {
+      "path": "../../core/editor"
+    }
+  ]
+}

--- a/packages/plugins/table-of-contents/src/index.ts
+++ b/packages/plugins/table-of-contents/src/index.ts
@@ -5,7 +5,6 @@ import type {
   TableOfContentsElementMap,
   TableOfContentsElementProps,
 } from './types';
-import { DEFAULT_HEADING_TYPES, HEADING_TYPE_LEVEL } from './types';
 
 export { TableOfContentsCommands } from './commands';
 export { DEFAULT_HEADING_TYPES, HEADING_TYPE_LEVEL } from './types';
@@ -20,7 +19,6 @@ export type {
   TableOfContentsElementProps,
 };
 export type {
-  TableOfContentsEditor,
   TableOfContentsItem,
   UseTableOfContentsItemsOptions,
 } from './useTableOfContentsItems';

--- a/packages/plugins/video/src/index.ts
+++ b/packages/plugins/video/src/index.ts
@@ -1,9 +1,9 @@
 import { Video } from './plugin/video-plugin';
-import { VideoElement, VideoElementProps, VideoPluginOptions, VideoUploadResponse } from './types';
+import { VideoElement, VideoElementProps, VideoPluginOptions, VideoUploadResponse, VideoUploadPreview, VideoUploadProgress } from './types';
 
 export { VideoCommands } from './commands';
 export { useVideoUpload, useVideoDelete, useVideoPosterUpload, useVideoPreview, useVideoDimensions } from './hooks/use-upload';
 export { parseVideoUrl, buildVideoProvider, getEmbedUrl, getProvider, isValidVideoUrl, isProviderUrl, getSupportedProviders, isProviderSupported } from './utils/providers';
 
 export default Video;
-export { VideoElement, VideoElementProps, VideoUploadResponse, VideoPluginOptions };
+export { VideoElement, VideoElementProps, VideoUploadResponse, VideoPluginOptions, VideoUploadPreview, VideoUploadProgress };

--- a/packages/themes/shadcn/package.json
+++ b/packages/themes/shadcn/package.json
@@ -50,6 +50,9 @@
       "lists": [
         "./dist/types/lists/index.d.ts"
       ],
+      "math": [
+        "./dist/types/math/index.d.ts"
+      ],
       "mention": [
         "./dist/types/mention/index.d.ts"
       ],
@@ -133,6 +136,10 @@
     "./lists": {
       "types": "./dist/types/lists/index.d.ts",
       "import": "./dist/lists.js"
+    },
+    "./math": {
+      "types": "./dist/types/math/index.d.ts",
+      "import": "./dist/math.js"
     },
     "./mention": {
       "types": "./dist/types/mention/index.d.ts",

--- a/packages/themes/shadcn/rollup.config.js
+++ b/packages/themes/shadcn/rollup.config.js
@@ -106,6 +106,7 @@ const createMultiEntryConfig = () => {
       image: './src/image/index.ts',
       link: './src/link/index.ts',
       lists: './src/lists/index.ts',
+      math: './src/math/index.ts',
       mention: './src/mention/index.ts',
       paragraph: './src/paragraph/index.ts',
       steps: './src/steps/index.ts',

--- a/packages/themes/shadcn/src/applyTheme.ts
+++ b/packages/themes/shadcn/src/applyTheme.ts
@@ -13,6 +13,7 @@ import { HeadingsUI } from './headings';
 import { ImageUI } from './image';
 import { LinkUI } from './link';
 import { ListsUI } from './lists';
+import { MathInlineUI, MathBlockUI } from './math';
 import { MentionUI } from './mention';
 import { ParagraphUI } from './paragraph';
 import { StepsUI } from './steps';
@@ -89,6 +90,8 @@ export function applyTheme(
     Embed: EmbedUI,
     File: FileUI,
     Mention: MentionUI,
+    MathInline: MathInlineUI,
+    MathBlock: MathBlockUI,
   };
 
   return plugins.map((plugin) => {

--- a/packages/themes/shadcn/src/embed/elements/embed/embed-inline-toolbar.tsx
+++ b/packages/themes/shadcn/src/embed/elements/embed/embed-inline-toolbar.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
 import { FloatingPortal, autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react';
+import { useYooptaEditor } from '@yoopta/editor';
 import copy from 'copy-to-clipboard';
 import { AlignCenter, AlignLeft, AlignRight, Copy, ExternalLink, RotateCw, Trash2 } from 'lucide-react';
 
@@ -31,6 +32,7 @@ export const EmbedInlineToolbar = ({
   const hasProvider = elementProps.provider && elementProps.provider.type;
   const hasAlignment = 'alignment' in elementProps;
 
+  const editor = useYooptaEditor();
   const { refs, floatingStyles } = useFloating({
     placement: 'top-end',
     strategy: 'absolute',
@@ -81,7 +83,7 @@ export const EmbedInlineToolbar = ({
   if (!isReady) return null;
 
   return (
-    <FloatingPortal>
+    <FloatingPortal id='embed-inline-toolbar' root={editor.refElement}>
       <div
         ref={refs.setFloating}
         onMouseDown={(e) => {

--- a/packages/themes/shadcn/src/file/elements/file/file-inline-toolbar.tsx
+++ b/packages/themes/shadcn/src/file/elements/file/file-inline-toolbar.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
 import { FloatingPortal, autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react';
+import { useYooptaEditor } from '@yoopta/editor';
 import copy from 'copy-to-clipboard';
 import { Copy, Download, ExternalLink, RotateCw, Trash2 } from 'lucide-react';
 
@@ -26,6 +27,7 @@ export const FileInlineToolbar = ({
   const [isVisible, setIsVisible] = useState(false);
   const [isReady, setIsReady] = useState(false);
 
+  const editor = useYooptaEditor();
   const { refs, floatingStyles } = useFloating({
     placement: 'top-end',
     strategy: 'absolute',
@@ -86,7 +88,7 @@ export const FileInlineToolbar = ({
   if (!isReady) return null;
 
   return (
-    <FloatingPortal>
+    <FloatingPortal id='file-inline-toolbar' root={editor.refElement}>
       <div
         ref={refs.setFloating}
         onMouseDown={(e) => {

--- a/packages/themes/shadcn/src/image/elements/image/image-inline-toolbar.tsx
+++ b/packages/themes/shadcn/src/image/elements/image/image-inline-toolbar.tsx
@@ -8,6 +8,7 @@ import { Separator } from '../../../ui/separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../../ui/tooltip';
 import { cn } from '../../../utils';
 import type { ImageElementProps } from '../../types';
+import { useYooptaEditor } from '@yoopta/editor';
 
 type ImageInlineToolbarProps = {
   referenceRef: React.MutableRefObject<HTMLElement | null>;
@@ -31,6 +32,7 @@ export const ImageInlineToolbar = ({
   const [isVisible, setIsVisible] = useState(false);
   const [isReady, setIsReady] = useState(false);
 
+  const editor = useYooptaEditor();
   const { refs, floatingStyles } = useFloating({
     placement: 'top-end',
     strategy: 'absolute',
@@ -70,7 +72,7 @@ export const ImageInlineToolbar = ({
   if (!isReady) return null;
 
   return (
-    <FloatingPortal>
+    <FloatingPortal id='image-inline-toolbar' root={editor.refElement}>
       <div
         ref={refs.setFloating}
         onMouseDown={(e) => {

--- a/packages/themes/shadcn/src/index.ts
+++ b/packages/themes/shadcn/src/index.ts
@@ -9,6 +9,7 @@ export { ParagraphUI } from './paragraph';
 export { CalloutUI } from './callout';
 export { ListsUI } from './lists';
 export { LinkUI } from './link';
+export { MathInlineUI, MathBlockUI } from './math';
 export { MentionUI, MentionDropdown } from './mention';
 export { EmojiDropdown } from './emoji';
 export { ImageUI } from './image';

--- a/packages/themes/shadcn/src/math/elements/math-block/math-block-element.tsx
+++ b/packages/themes/shadcn/src/math/elements/math-block/math-block-element.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react';
+import type { PluginElementRenderProps } from '@yoopta/editor';
+import { Elements, useYooptaEditor, useYooptaReadOnly } from '@yoopta/editor';
+import type { MathBlockElementProps } from '@yoopta/math';
+import { renderLatexToHTML } from '@yoopta/math';
+import copy from 'copy-to-clipboard';
+import { Check, Copy, Edit2, Trash2 } from 'lucide-react';
+
+import { Button } from '../../../ui/button';
+import { Label } from '../../../ui/label';
+import { cn } from '../../../utils';
+
+export const MathBlockElement = (props: PluginElementRenderProps) => {
+  const { attributes, children, element, blockId } = props;
+  const editor = useYooptaEditor();
+  const isReadOnly = useYooptaReadOnly();
+
+  const { latex } = element.props as MathBlockElementProps;
+
+  const [isEditing, setIsEditing] = useState(!latex);
+  const [editedLatex, setEditedLatex] = useState(latex ?? '');
+  const [copied, setCopied] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setEditedLatex(latex ?? '');
+  }, [latex]);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [isEditing]);
+
+  const saveEdit = () => {
+    if (isReadOnly) return;
+
+    const elementPath = Elements.getElementPath(editor, { blockId, element });
+    if (!elementPath) return;
+
+    Elements.updateElement(editor, {
+      blockId,
+      type: 'math-block',
+      path: elementPath,
+      props: { latex: editedLatex },
+    });
+    setIsEditing(false);
+  };
+
+  const cancelEdit = () => {
+    setEditedLatex(latex ?? '');
+    if (latex) setIsEditing(false);
+  };
+
+  const deleteMathBlock = () => {
+    if (isReadOnly) return;
+    editor.deleteBlock({ blockId });
+  };
+
+  const copyLatex = () => {
+    if (latex) {
+      const success = copy(latex);
+      if (success) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      e.stopPropagation();
+      saveEdit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      cancelEdit();
+    }
+  };
+
+  const renderedHtml = renderLatexToHTML(latex || '', true);
+  const previewHtml = renderLatexToHTML(editedLatex || '', true);
+  const hasLatex = !!latex && latex.trim() !== '';
+
+  return (
+    <div
+      {...attributes}
+      contentEditable={false}
+      data-math-block
+      data-latex={latex}
+      className={cn(
+        'rounded-lg transition-colors my-2 hover:bg-violet-500/5',
+        isEditing
+          ? 'border-violet-500/40 bg-violet-500/5'
+          : hasLatex
+            ? 'bg-card hover:border-violet-500/30 cursor-pointer'
+            : 'bg-muted/20 cursor-pointer',
+      )}
+    >
+      {isEditing && !isReadOnly ? (
+        <div>
+          {/* Live preview */}
+          <div className="px-2 py-2 flex items-center justify-center bg-muted/10">
+            {editedLatex.trim() ? (
+              <span
+                className="text-lg text-foreground"
+                dangerouslySetInnerHTML={{ __html: previewHtml }}
+              />
+            ) : (
+              <span className="text-sm text-muted-foreground italic">
+                Type a LaTeX expression below...
+              </span>
+            )}
+          </div>
+
+          {/* Editor */}
+          <div className="p-3 space-y-2">
+            <div className="space-y-1">
+              <Label htmlFor="math-block-latex" className="text-xs">
+                LaTeX Expression
+              </Label>
+              <textarea
+                id="math-block-latex"
+                ref={textareaRef}
+                value={editedLatex}
+                onChange={(e) => setEditedLatex(e.target.value)}
+                onKeyDown={onKeyDown}
+                placeholder="e.g. \int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}"
+                rows={3}
+                className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 resize-y min-h-[60px]"
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+              />
+              <p className="text-[10px] text-muted-foreground">
+                {/Mac|iPhone|iPad/.test(navigator.userAgent) ? '⌘' : 'Ctrl'}+Enter to save, Esc to
+                cancel
+              </p>
+            </div>
+            <div className="flex justify-between items-center">
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="h-7 text-xs"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    saveEdit();
+                  }}
+                  disabled={!editedLatex.trim()}
+                >
+                  Save
+                </Button>
+                {hasLatex && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-xs"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      cancelEdit();
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                )}
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  deleteMathBlock();
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div
+          onClick={() => !isReadOnly && setIsEditing(true)}
+          className="relative group"
+        >
+          {/* Rendered math */}
+          <div className="px-2 py-2 flex items-center justify-center">
+            {hasLatex ? (
+              <span
+                className="text-lg text-foreground"
+                dangerouslySetInnerHTML={{ __html: renderedHtml }}
+              />
+            ) : (
+              <span className="text-sm text-muted-foreground italic">
+                Click to add a math equation
+              </span>
+            )}
+          </div>
+
+          {/* Hover actions */}
+          {hasLatex && (
+            <div className="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-6 w-6 p-0"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  copyLatex();
+                }}
+                title={copied ? 'Copied!' : 'Copy LaTeX'}
+              >
+                {copied ? (
+                  <Check className="h-3 w-3 text-green-600 dark:text-green-400" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+              </Button>
+              {!isReadOnly && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="h-6 w-6 p-0"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsEditing(true);
+                  }}
+                  title="Edit expression"
+                >
+                  <Edit2 className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+};

--- a/packages/themes/shadcn/src/math/elements/math/math-edit.tsx
+++ b/packages/themes/shadcn/src/math/elements/math/math-edit.tsx
@@ -1,0 +1,98 @@
+import { renderLatexToHTML } from '@yoopta/math';
+import { Trash2 } from 'lucide-react';
+
+import { Button } from '../../../ui/button';
+import { Label } from '../../../ui/label';
+
+type MathEditProps = {
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  editedLatex: string;
+  onChangeLatex: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  saveEdit: (e: React.MouseEvent) => void;
+  cancelEdit: (e: React.MouseEvent) => void;
+  deleteMath: (e: React.MouseEvent) => void;
+};
+
+export const MathEdit = ({
+  textareaRef,
+  editedLatex,
+  onChangeLatex,
+  onKeyDown,
+  saveEdit,
+  cancelEdit,
+  deleteMath,
+}: MathEditProps) => {
+  const previewHtml = renderLatexToHTML(editedLatex || '', false);
+  const hasContent = editedLatex.trim().length > 0;
+
+  return (
+    <div>
+      {/* Live preview */}
+      <div className="px-3 py-2.5 flex items-center justify-center min-h-[40px] border-b bg-muted/20">
+        {hasContent ? (
+          <span
+            className="text-base text-foreground"
+            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          />
+        ) : (
+          <span className="text-sm text-muted-foreground italic">Type LaTeX below...</span>
+        )}
+      </div>
+
+      {/* LaTeX input */}
+      <div className="p-2 space-y-2">
+        <div className="space-y-1">
+          <Label htmlFor="math-latex" className="text-xs">
+            LaTeX Expression
+          </Label>
+          <textarea
+            id="math-latex"
+            ref={textareaRef}
+            value={editedLatex}
+            onChange={onChangeLatex}
+            onKeyDown={onKeyDown}
+            placeholder="e.g. E = mc^2"
+            rows={2}
+            className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 resize-none"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          />
+          <p className="text-[10px] text-muted-foreground">
+            {/Mac|iPhone|iPad/.test(navigator.userAgent) ? '⌘' : 'Ctrl'}+Enter to save, Esc to cancel
+          </p>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="default"
+              className="h-7 text-xs"
+              onClick={saveEdit}
+              disabled={!hasContent}
+            >
+              Save
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs"
+              onClick={cancelEdit}
+            >
+              Cancel
+            </Button>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+            onClick={deleteMath}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/themes/shadcn/src/math/elements/math/math-element.tsx
+++ b/packages/themes/shadcn/src/math/elements/math/math-element.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useRef, useState } from 'react';
+import type { PluginElementRenderProps } from '@yoopta/editor';
+import { Elements, useYooptaEditor, useYooptaReadOnly } from '@yoopta/editor';
+import type { MathInlineElementProps } from '@yoopta/math';
+import { renderLatexToHTML } from '@yoopta/math';
+import copy from 'copy-to-clipboard';
+
+import { MathEdit } from './math-edit';
+import { MathPreview } from './math-preview';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '../../../ui/hover-card';
+import { cn } from '../../../utils';
+
+export const MathElement = (props: PluginElementRenderProps) => {
+  const { attributes, children, element, blockId } = props;
+  const editor = useYooptaEditor();
+  const isReadOnly = useYooptaReadOnly();
+
+  const { latex } = element.props as MathInlineElementProps;
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedLatex, setEditedLatex] = useState(latex ?? '');
+  const [copied, setCopied] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setEditedLatex(latex ?? '');
+  }, [latex]);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, [isEditing]);
+
+  const openEdit = (e: React.MouseEvent) => {
+    if (isReadOnly) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setIsEditing(true);
+  };
+
+  const saveEdit = (e: React.MouseEvent) => {
+    if (isReadOnly) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    const elementPath = Elements.getElementPath(editor, {
+      blockId,
+      element,
+    });
+
+    if (!elementPath) return;
+
+    Elements.updateElement(editor, {
+      blockId,
+      type: 'math-inline',
+      path: elementPath,
+      props: { latex: editedLatex },
+    });
+    setIsEditing(false);
+  };
+
+  const cancelEdit = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setEditedLatex(latex ?? '');
+    setIsEditing(false);
+  };
+
+  const deleteMath = (e: React.MouseEvent) => {
+    if (isReadOnly) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    const elementPath = Elements.getElementPath(editor, {
+      blockId,
+      element,
+    });
+
+    if (!elementPath) return;
+
+    Elements.deleteElement(editor, {
+      type: 'math-inline',
+      path: elementPath,
+      blockId,
+    });
+    setIsEditing(false);
+  };
+
+  const copyLatex = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (latex) {
+      const success = copy(latex);
+      if (success) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const elementPath = Elements.getElementPath(editor, {
+        blockId,
+        element,
+      });
+
+      if (!elementPath) return;
+
+      Elements.updateElement(editor, {
+        blockId,
+        type: 'math-inline',
+        path: elementPath,
+        props: { latex: editedLatex },
+      });
+      setIsEditing(false);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      setEditedLatex(latex ?? '');
+      setIsEditing(false);
+    }
+  };
+
+  const renderedHtml = renderLatexToHTML(latex || '?', false);
+  const hasError = !latex || latex.trim() === '';
+
+  return (
+    <HoverCard openDelay={100} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <span
+          {...attributes}
+          contentEditable={false}
+          data-math-inline
+          data-latex={latex}
+          className={cn(
+            'inline-flex items-center align-baseline',
+            'transition-colors cursor-pointer',
+            hasError
+              ? 'bg-destructive/10 text-destructive'
+              : 'bg-violet-500/10 text-violet-700 dark:text-violet-300 hover:bg-violet-500/15',
+          )}
+          style={{
+            borderRadius: '0.25rem',
+            padding: '0.1em 0.35em',
+            margin: '0 0.1em',
+            fontSize: '0.95em',
+            lineHeight: 1.4,
+            verticalAlign: 'baseline',
+          }}
+        >
+          <span dangerouslySetInnerHTML={{ __html: renderedHtml }} />
+          {children}
+        </span>
+      </HoverCardTrigger>
+
+      <HoverCardContent
+        className="w-80 p-0"
+        side="top"
+        align="start"
+        sideOffset={8}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {!isReadOnly && isEditing ? (
+          <MathEdit
+            textareaRef={textareaRef}
+            editedLatex={editedLatex}
+            onChangeLatex={(e) => setEditedLatex(e.target.value)}
+            onKeyDown={onKeyDown}
+            saveEdit={saveEdit}
+            cancelEdit={cancelEdit}
+            deleteMath={deleteMath}
+          />
+        ) : (
+          <MathPreview
+            latex={latex}
+            openEdit={openEdit}
+            copyLatex={copyLatex}
+            copied={copied}
+          />
+        )}
+      </HoverCardContent>
+    </HoverCard>
+  );
+};

--- a/packages/themes/shadcn/src/math/elements/math/math-preview.tsx
+++ b/packages/themes/shadcn/src/math/elements/math/math-preview.tsx
@@ -1,0 +1,79 @@
+import { useYooptaReadOnly } from '@yoopta/editor';
+import { renderLatexToHTML } from '@yoopta/math';
+import { Check, Copy, Edit2 } from 'lucide-react';
+
+import { Button } from '../../../ui/button';
+
+type MathPreviewProps = {
+  latex: string;
+  openEdit: (e: React.MouseEvent) => void;
+  copyLatex: (e: React.MouseEvent) => void;
+  copied: boolean;
+};
+
+export const MathPreview = ({
+  latex,
+  openEdit,
+  copyLatex,
+  copied,
+}: MathPreviewProps) => {
+  const isReadOnly = useYooptaReadOnly();
+  const renderedHtml = renderLatexToHTML(latex || '', false);
+
+  return (
+    <div>
+      {/* Rendered math preview */}
+      <div className="px-3 py-2.5 flex items-center justify-center min-h-[40px] border-b">
+        {latex ? (
+          <span
+            className="text-base text-foreground"
+            dangerouslySetInnerHTML={{ __html: renderedHtml }}
+          />
+        ) : (
+          <span className="text-sm text-muted-foreground italic">Empty expression</span>
+        )}
+      </div>
+
+      {/* LaTeX source */}
+      <div className="px-3 py-1.5 border-b bg-muted/30">
+        <code className="text-xs text-muted-foreground font-mono break-all">
+          {latex || '—'}
+        </code>
+      </div>
+
+      {/* Actions */}
+      <div className="px-2 py-1">
+        <div className="flex items-center gap-1">
+          <div className="flex-1 min-w-0">
+            <span className="text-xs text-muted-foreground">Inline Math</span>
+          </div>
+          <div className="h-4 w-px bg-border" />
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0"
+            onClick={copyLatex}
+            title={copied ? 'Copied!' : 'Copy LaTeX'}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </Button>
+          {!isReadOnly && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 w-7 p-0"
+              onClick={openEdit}
+              title="Edit expression"
+            >
+              <Edit2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/themes/shadcn/src/math/index.ts
+++ b/packages/themes/shadcn/src/math/index.ts
@@ -1,0 +1,19 @@
+import { MathElement } from './elements/math/math-element';
+import { MathBlockElement } from './elements/math-block/math-block-element';
+
+export { MathElement } from './elements/math/math-element';
+export { MathPreview } from './elements/math/math-preview';
+export { MathEdit } from './elements/math/math-edit';
+export { MathBlockElement } from './elements/math-block/math-block-element';
+
+export const MathInlineUI = {
+  'math-inline': {
+    render: MathElement,
+  },
+};
+
+export const MathBlockUI = {
+  'math-block': {
+    render: MathBlockElement,
+  },
+};

--- a/packages/themes/shadcn/src/table-of-contents/elements/table-of-contents.tsx
+++ b/packages/themes/shadcn/src/table-of-contents/elements/table-of-contents.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import type { PluginElementRenderProps } from '@yoopta/editor';
 import { useYooptaEditor } from '@yoopta/editor';
 import {
-  type TableOfContentsEditor,
   type TableOfContentsElementProps,
   type TableOfContentsItem,
   useTableOfContentsItems,
@@ -60,7 +59,7 @@ export const TableOfContents = (props: PluginElementRenderProps) => {
   } = tocProps;
 
   const [isExpanded, setIsExpanded] = useState(true);
-  const items = useTableOfContentsItems(editor as TableOfContentsEditor, blockId, {
+  const items = useTableOfContentsItems(editor, blockId, {
     depth,
     headingTypes,
   });

--- a/packages/themes/shadcn/src/ui/button.tsx
+++ b/packages/themes/shadcn/src/ui/button.tsx
@@ -6,7 +6,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { cn } from '../utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'cursor-pointer inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/packages/themes/shadcn/src/video/elements/video/video-inline-toolbar.tsx
+++ b/packages/themes/shadcn/src/video/elements/video/video-inline-toolbar.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
 import { FloatingPortal, autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react';
+import { useYooptaEditor } from '@yoopta/editor';
 import copy from 'copy-to-clipboard';
 import { AlignCenter, AlignLeft, AlignRight, Copy, Download, ExternalLink, RotateCw, Trash2 } from 'lucide-react';
 
@@ -34,6 +35,7 @@ export const VideoInlineToolbar = ({
   const isProviderVideo = elementProps.provider && elementProps.provider.type;
   const hasAlignment = 'alignment' in elementProps;
 
+  const editor = useYooptaEditor();
   const { refs, floatingStyles } = useFloating({
     placement: 'top-end',
     strategy: 'absolute',
@@ -97,7 +99,7 @@ export const VideoInlineToolbar = ({
   if (!isReady) return null;
 
   return (
-    <FloatingPortal>
+    <FloatingPortal id='video-inline-toolbar' root={editor.refElement}>
       <div
         ref={refs.setFloating}
         onMouseDown={(e) => {

--- a/web/next-app-example/app/examples/full-setup/initial-value.ts
+++ b/web/next-app-example/app/examples/full-setup/initial-value.ts
@@ -1711,6 +1711,119 @@ export const fullSetupInitialValue: YooptaContentValue = {
       "depth": 0
     }
   },
+  "fs-h2-math": {
+    "id": "fs-h2-math",
+    "type": "HeadingTwo",
+    "value": [
+      {
+        "id": "fs-h2-math-el",
+        "type": "heading-two",
+        "children": [
+          {
+            "text": "Math Expressions"
+          }
+        ],
+        "props": {
+          "nodeType": "block"
+        }
+      }
+    ],
+    "meta": {
+      "order": 47,
+      "depth": 0
+    }
+  },
+  "fs-p-math": {
+    "id": "fs-p-math",
+    "type": "Paragraph",
+    "value": [
+      {
+        "id": "fs-p-math-el",
+        "type": "paragraph",
+        "children": [
+          {
+            "text": "Yoopta supports inline math via KaTeX. For example, Euler's identity "
+          },
+          {
+            "id": "fs-math-inline-1",
+            "type": "math-inline",
+            "children": [{ "text": "" }],
+            "props": {
+              "latex": "e^{i\\pi} + 1 = 0",
+              "nodeType": "inlineVoid"
+            }
+          },
+          {
+            "text": " is often called the most beautiful equation in mathematics. You can also write inline expressions like "
+          },
+          {
+            "id": "fs-math-inline-2",
+            "type": "math-inline",
+            "children": [{ "text": "" }],
+            "props": {
+              "latex": "\\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}",
+              "nodeType": "inlineVoid"
+            }
+          },
+          {
+            "text": " right inside any text block."
+          }
+        ],
+        "props": {
+          "nodeType": "block"
+        }
+      }
+    ],
+    "meta": {
+      "order": 48,
+      "depth": 0
+    }
+  },
+  "fs-p-math-block": {
+    "id": "fs-p-math-block",
+    "type": "Paragraph",
+    "value": [
+      {
+        "id": "fs-p-math-block-el",
+        "type": "paragraph",
+        "children": [
+          {
+            "text": "For larger, display-mode equations, use a dedicated Math Block:"
+          }
+        ],
+        "props": {
+          "nodeType": "block"
+        }
+      }
+    ],
+    "meta": {
+      "order": 49,
+      "depth": 0
+    }
+  },
+  "fs-math-block": {
+    "id": "fs-math-block",
+    "type": "MathBlock",
+    "value": [
+      {
+        "id": "fs-math-block-el",
+        "type": "math-block",
+        "children": [
+          {
+            "text": ""
+          }
+        ],
+        "props": {
+          "latex": "\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}",
+          "nodeType": "void"
+        }
+      }
+    ],
+    "meta": {
+      "order": 50,
+      "depth": 0
+    }
+  },
   "fs-divider-3": {
     "id": "fs-divider-3",
     "type": "Divider",
@@ -1730,7 +1843,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 47,
+      "order": 51,
       "depth": 0
     }
   },
@@ -1752,7 +1865,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 48,
+      "order": 52,
       "depth": 0
     }
   },
@@ -1774,7 +1887,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 49,
+      "order": 53,
       "depth": 0
     }
   },
@@ -1803,7 +1916,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 50,
+      "order": 54,
       "depth": 0
     }
   },
@@ -1832,7 +1945,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 51,
+      "order": 55,
       "depth": 0
     }
   },
@@ -1865,7 +1978,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 52,
+      "order": 56,
       "depth": 0
     }
   },
@@ -1908,7 +2021,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 53,
+      "order": 57,
       "depth": 0
     }
   },
@@ -1931,7 +2044,7 @@ export const fullSetupInitialValue: YooptaContentValue = {
       }
     ],
     "meta": {
-      "order": 54,
+      "order": 58,
       "depth": 0
     }
   },

--- a/web/next-app-example/components/playground/examples/full-setup/new-yoo-components/yoopta-toolbar.tsx
+++ b/web/next-app-example/components/playground/examples/full-setup/new-yoo-components/yoopta-toolbar.tsx
@@ -4,10 +4,13 @@ import {
   CodeIcon,
   BoldIcon,
   ItalicIcon,
+  SigmaIcon,
   Strikethrough,
   Underline,
 } from 'lucide-react';
-import { Marks, useYooptaEditor } from '@yoopta/editor';
+import { Blocks, Marks, useYooptaEditor } from '@yoopta/editor';
+import { MathInlineCommands } from '@yoopta/math';
+import { Editor, Range } from 'slate';
 import { FloatingToolbar } from '@yoopta/ui/floating-toolbar';
 import { HighlightColorPicker } from '@yoopta/ui/highlight-color-picker';
 import { HighlighterIcon } from 'lucide-react';
@@ -24,6 +27,25 @@ export const YooptaToolbar = () => {
 
   const onTurnIntoClick = () => {
     setActionMenuOpen(true);
+  };
+
+  const onInsertMath = () => {
+    if (editor.path.current === null) return;
+
+    const currentBlockId = Object.keys(editor.children).find((id) => {
+      return editor.children[id]?.meta.order === editor.path.current;
+    });
+    if (!currentBlockId) return;
+
+    const slate = Blocks.getBlockSlate(editor, { id: currentBlockId });
+    if (!slate || !slate.selection) return;
+
+    // Use selected text as the LaTeX expression, otherwise fall back to placeholder
+    const selectedText = !Range.isCollapsed(slate.selection)
+      ? Editor.string(slate, slate.selection)
+      : '';
+
+    MathInlineCommands.insertMathInline(editor, selectedText || 'E = mc^2', { slate });
   };
 
   return (
@@ -125,6 +147,19 @@ export const YooptaToolbar = () => {
               </HighlightColorPicker>
             )}
           </FloatingToolbar.Group>
+          {editor.plugins.MathInline && (
+            <>
+              <FloatingToolbar.Separator />
+              <FloatingToolbar.Group>
+                <FloatingToolbar.Button
+                  onClick={onInsertMath}
+                  title="Insert Math"
+                >
+                  <SigmaIcon />
+                </FloatingToolbar.Button>
+              </FloatingToolbar.Group>
+            </>
+          )}
         </FloatingToolbar.Content>
       </FloatingToolbar>
 

--- a/web/next-app-example/components/playground/examples/full-setup/plugins.ts
+++ b/web/next-app-example/components/playground/examples/full-setup/plugins.ts
@@ -17,7 +17,10 @@ import Tabs from '@yoopta/tabs';
 import Steps from '@yoopta/steps';
 import Carousel from '@yoopta/carousel';
 import Mention from '@yoopta/mention';
+import { MathInline, MathBlock } from '@yoopta/math';
 import TableOfContents from '@yoopta/table-of-contents';
+
+import 'katex/dist/katex.min.css';
 
 const YImage = Image.extend({
   options: {
@@ -126,4 +129,6 @@ export const YOOPTA_PLUGINS = [
       triggers: [{ char: '@', type: 'user' }, { char: '#', type: 'page' }],
     },
   }),
+  MathInline,
+  MathBlock,
 ];

--- a/web/next-app-example/lib/icons.ts
+++ b/web/next-app-example/lib/icons.ts
@@ -18,6 +18,7 @@ import {
   PanelLeftIcon,
   GridIcon,
   TableOfContentsIcon,
+  RadicalIcon,
 } from 'lucide-react';
 
 export const COMMAND_MENU_DEFAULT_ICONS_MAP: Record<string, React.ComponentType<{ width?: number; height?: number }>> = {
@@ -43,4 +44,5 @@ export const COMMAND_MENU_DEFAULT_ICONS_MAP: Record<string, React.ComponentType<
   CodeGroup: CodeIcon,
   Carousel: GridIcon,
   TableOfContents: TableOfContentsIcon,
+  MathBlock: RadicalIcon,
 };

--- a/web/next-app-example/package.json
+++ b/web/next-app-example/package.json
@@ -36,6 +36,7 @@
     "@yoopta/link": "workspace:*",
     "@yoopta/lists": "workspace:*",
     "@yoopta/marks": "workspace:*",
+    "@yoopta/math": "workspace:*",
     "@yoopta/mention": "workspace:*",
     "@yoopta/paragraph": "workspace:*",
     "@yoopta/steps": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6552,6 +6552,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@yoopta/math@workspace:*, @yoopta/math@workspace:packages/plugins/math":
+  version: 0.0.0-use.local
+  resolution: "@yoopta/math@workspace:packages/plugins/math"
+  dependencies:
+    katex: "npm:^0.16.11"
+  peerDependencies:
+    "@yoopta/editor": 6.0.2
+    react: ">=18.2.0"
+    react-dom: ">=18.2.0"
+  languageName: unknown
+  linkType: soft
+
 "@yoopta/mention@workspace:*, @yoopta/mention@workspace:packages/plugins/mention":
   version: 0.0.0-use.local
   resolution: "@yoopta/mention@workspace:packages/plugins/mention"
@@ -6672,6 +6684,7 @@ __metadata:
     "@yoopta/file": ^6.0.2
     "@yoopta/image": ^6.0.2
     "@yoopta/lists": ^6.0.2
+    "@yoopta/math": ^6.0.2
     "@yoopta/steps": ^6.0.2
     "@yoopta/table": ^6.0.2
     "@yoopta/table-of-contents": ^6.0.2
@@ -7672,6 +7685,13 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
+  languageName: node
+  linkType: hard
+
+"commander@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 10c0/8b043bb8322ea1c39664a1598a95e0495bfe4ca2fad0d84a92d7d1d8d213e2a155b441d2470c8e08de7c4a28cf2bc6e169211c49e1b21d9f7edc6ae4d9356060
   languageName: node
   linkType: hard
 
@@ -11050,6 +11070,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"katex@npm:^0.16.11":
+  version: 0.16.45
+  resolution: "katex@npm:0.16.45"
+  dependencies:
+    commander: "npm:^8.3.0"
+  bin:
+    katex: cli.js
+  checksum: 10c0/f715eb9a73daff68ac14dcc8c2f47f02f5fc756a74077d22479e64e06872b2b44f0d81f1c91a98a9873722a08841388a869a0b9ddb96b224362eb8054ddf533a
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.3, keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -11921,6 +11952,7 @@ __metadata:
     "@yoopta/link": "workspace:*"
     "@yoopta/lists": "workspace:*"
     "@yoopta/marks": "workspace:*"
+    "@yoopta/math": "workspace:*"
     "@yoopta/mention": "workspace:*"
     "@yoopta/paragraph": "workspace:*"
     "@yoopta/steps": "workspace:*"


### PR DESCRIPTION
- Introduced the `@yoopta/math` package, enabling inline and block math expressions rendered with KaTeX.
- Added `MathInline` and `MathBlock` plugins for seamless integration of LaTeX in text.
- Updated documentation to include installation instructions, usage examples, and detailed API references for the new math features.
- Enhanced existing README and introduction files to reflect the addition of math capabilities.
- Updated yarn.lock to include new dependencies for the math plugin.

