### PR TITLE
Implement getRootElement function and enhance plugin management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ Elements.getElementEntry(editor, { ... })
 Elements.getElementPath(editor, { ... })
 Elements.getParentElementPath(editor, { ... })
 Elements.getElementChildren(editor, { ... })
+Elements.getRootElement(editor, { ... })
 Elements.isElementEmpty(editor, { ... })
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Elements.getElementEntry(editor, { ... })
 Elements.getElementPath(editor, { ... })
 Elements.getParentElementPath(editor, { ... })
 Elements.getElementChildren(editor, { ... })
+Elements.getRootElement(editor, { ... })
 Elements.isElementEmpty(editor, { ... })
 ```
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Elements.getElementEntry(editor, { ... }) // Get element with path
 Elements.getElementPath(editor, { ... })  // Get path to element
 Elements.getParentElementPath(editor, { ... }) // Get parent path
 Elements.getElementChildren(editor, { ... })   // Get child elements
+Elements.getRootElement(editor, { ... })  // Get root element definition for a plugin
 Elements.isElementEmpty(editor, { ... })  // Check if element is empty
 ```
 

--- a/docs/api-reference/editor.mdx
+++ b/docs/api-reference/editor.mdx
@@ -97,7 +97,7 @@ Available on the instance; see [Elements API](/api-reference/elements) for full 
 - `insertElement`, `updateElement`, `deleteElement`
 - `getElement`, `getElements`, `getElementEntry`
 - `getElementPath`, `getParentElementPath`, `getElementRect`
-- `getElementChildren`, `isElementEmpty`
+- `getElementChildren`, `getRootElement`, `isElementEmpty`
 
 ---
 
@@ -139,7 +139,7 @@ editor.y.inline(type: string, options?: ElementStructureOptions): SlateElement
 - **`editor.once(event, callback)`** — Subscribe once.
 - **`editor.emit(event, payload)`** — Emit event.
 
-**Events:** `'change'` (payload: `{ operations, value }`), `'focus'`, `'blur'`, `'block:copy'`, `'path-change'`.
+**Events:** `'change'` (payload: `{ operations, value }`), `'focus'`, `'blur'`, `'block:copy'`, `'path-change'`, `'plugin:register'` (payload: `{ type }`), `'plugin:unregister'` (payload: `{ type }`).
 
 ---
 
@@ -210,3 +210,82 @@ editor.batchOperations(() => {
 - **`editor.plugins`** — Resolved plugin map.
 - **`editor.blockEditorsMap`** — Map of block ID to Slate editor (internal).
 - **`editor.refElement`** — DOM element ref when used with the editor component.
+
+---
+
+### Runtime plugin management
+
+#### registerPlugin
+
+Registers a plugin at runtime into an already-initialized editor. Useful for dynamically adding block types — loading from a marketplace, enabling optional plugins based on user settings, or lazy-loading heavy plugins.
+
+```typescript
+editor.registerPlugin(plugin: YooptaPlugin<Record<string, SlateElement>>): void
+```
+
+**Parameters:**
+- `plugin` — A `YooptaPlugin` instance to register (required).
+
+**Behavior:**
+- If a plugin with the same type is already registered, the call is a **no-op** (silently skipped).
+- The full plugin map is rebuilt, including element injection resolution (`injectElementsFromPlugins`).
+- Emits `plugin:register` event with `{ type: string }`.
+
+```typescript
+import Table from '@yoopta/table';
+import Code from '@yoopta/code';
+
+// Register a single plugin
+editor.registerPlugin(Table);
+
+// Load and register a marketplace plugin
+import { loadMarketplacePlugin } from '@yoopta/editor';
+
+const { plugin } = await loadMarketplacePlugin(
+  'https://marketplace.yoopta.dev/plugins/image-gallery/1.0.0/bundle.mjs',
+);
+editor.registerPlugin(plugin);
+
+// Listen for registration
+editor.on('plugin:register', ({ type }) => {
+  console.log(`Plugin "${type}" registered`);
+});
+```
+
+#### unregisterPlugin
+
+Removes a plugin at runtime. All blocks of that plugin type are deleted from content.
+
+```typescript
+editor.unregisterPlugin(pluginType: string): void
+```
+
+**Parameters:**
+- `pluginType` — Plugin type name, PascalCase (required). E.g. `'Table'`, `'Code'`.
+
+**Behavior:**
+- If no plugin with the given type is registered, the call is a **no-op**.
+- **All blocks of that type are removed** from `editor.children` and their Slate editors are cleaned up. This is destructive and cannot be undone via `editor.undo()`.
+- The plugin map is rebuilt without the removed plugin.
+- Emits `plugin:unregister` event with `{ type: string }`.
+
+```typescript
+// Remove a plugin
+editor.unregisterPlugin('Table');
+
+// Toggle plugin on/off
+import Code from '@yoopta/code';
+
+function toggleCodePlugin(enabled: boolean) {
+  if (enabled) {
+    editor.registerPlugin(Code);
+  } else {
+    editor.unregisterPlugin('Code');
+  }
+}
+
+// Listen for removal
+editor.on('plugin:unregister', ({ type }) => {
+  console.log(`Plugin "${type}" removed`);
+});
+```

--- a/docs/api-reference/elements.mdx
+++ b/docs/api-reference/elements.mdx
@@ -325,6 +325,48 @@ const children = Elements.getElementChildren(editor, {
 
 ---
 
+### getRootElement
+
+Returns the root element definition for a given block type (plugin). Each plugin defines one or more elements — the root is either the only element in the map, or the one marked with `asRoot: true`.
+
+```typescript
+Elements.getRootElement(editor: YooEditor, options: GetRootElementOptions): PluginElement | undefined
+```
+
+**Parameters:**
+
+- `editor` — Editor instance (required).
+- `options.blockType` — Plugin type name, PascalCase (required). E.g. `'Paragraph'`, `'Accordion'`, `'Image'`.
+
+**Returns:** The root `PluginElement` definition, or `undefined` if the plugin doesn't exist, has no elements, or no element is marked as root in a multi-element plugin.
+
+```typescript
+// Get root element of a single-element plugin
+const root = Elements.getRootElement(editor, { blockType: 'Paragraph' });
+// => { render: ..., props: { nodeType: 'block' } }
+
+// Check if a plugin's root element is void
+const imageRoot = Elements.getRootElement(editor, { blockType: 'Image' });
+if (imageRoot?.props?.nodeType === 'void') {
+  // handle void element
+}
+
+// Multi-element plugin — returns the element with asRoot: true
+const accordionRoot = Elements.getRootElement(editor, { blockType: 'Accordion' });
+if (accordionRoot?.children) {
+  console.log('Child element types:', accordionRoot.children);
+}
+
+// Filter plugins by root element node type
+const blockPlugins = Object.keys(editor.plugins).filter((type) => {
+  const root = Elements.getRootElement(editor, { blockType: type });
+  const nodeType = root?.props?.nodeType;
+  return nodeType !== 'inline' && nodeType !== 'inlineVoid';
+});
+```
+
+---
+
 ### isElementEmpty
 
 Checks whether an element has no text content.

--- a/packages/core/editor/src/editor/elements/getRootElement.test.ts
+++ b/packages/core/editor/src/editor/elements/getRootElement.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { getRootElement } from './getRootElement';
+import type { YooEditor } from '../types';
+
+describe('getRootElement', () => {
+  let editor: Partial<YooEditor>;
+
+  beforeEach(() => {
+    editor = {
+      plugins: {
+        Paragraph: {
+          type: 'Paragraph',
+          elements: {
+            paragraph: {
+              render: () => null as any,
+              props: { nodeType: 'block' },
+            },
+          },
+        },
+        Accordion: {
+          type: 'Accordion',
+          elements: {
+            'accordion-list': {
+              render: () => null as any,
+              props: { nodeType: 'block' },
+              asRoot: true,
+              children: ['accordion-list-item'],
+            },
+            'accordion-list-item': {
+              render: () => null as any,
+              props: { nodeType: 'block' },
+            },
+          },
+        },
+        Image: {
+          type: 'Image',
+          elements: {
+            image: {
+              render: () => null as any,
+              props: { nodeType: 'void' },
+            },
+          },
+        },
+      },
+    } as any;
+  });
+
+  it('should return the single element as root when plugin has one element', () => {
+    const result = getRootElement(editor as YooEditor, { blockType: 'Paragraph' });
+
+    expect(result).toBeDefined();
+    expect(result?.props?.nodeType).toBe('block');
+  });
+
+  it('should return the element marked with asRoot when plugin has multiple elements', () => {
+    const result = getRootElement(editor as YooEditor, { blockType: 'Accordion' });
+
+    expect(result).toBeDefined();
+    expect(result?.asRoot).toBe(true);
+    expect(result?.children).toContain('accordion-list-item');
+  });
+
+  it('should return undefined for non-existent plugin', () => {
+    const result = getRootElement(editor as YooEditor, { blockType: 'NonExistent' });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when plugin has no elements', () => {
+    (editor.plugins as any).Empty = { type: 'Empty' };
+
+    const result = getRootElement(editor as YooEditor, { blockType: 'Empty' });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return void root element for void plugins', () => {
+    const result = getRootElement(editor as YooEditor, { blockType: 'Image' });
+
+    expect(result).toBeDefined();
+    expect(result?.props?.nodeType).toBe('void');
+  });
+
+  it('should return undefined when multi-element plugin has no asRoot marker', () => {
+    (editor.plugins as any).Broken = {
+      type: 'Broken',
+      elements: {
+        'broken-a': { render: () => null, props: { nodeType: 'block' } },
+        'broken-b': { render: () => null, props: { nodeType: 'block' } },
+      },
+    };
+
+    const result = getRootElement(editor as YooEditor, { blockType: 'Broken' });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/core/editor/src/editor/elements/getRootElement.ts
+++ b/packages/core/editor/src/editor/elements/getRootElement.ts
@@ -1,0 +1,50 @@
+import type { PluginElement, PluginElementsMap } from '../../plugins/types';
+import type { YooEditor } from '../types';
+import type { GetRootElementOptions } from './types';
+
+/**
+ * Find the root element type from a plugin's element definitions.
+ * If the plugin has a single element, that's the root.
+ * If it has multiple elements, the one with `asRoot: true` is the root.
+ */
+function resolveRootElementType(
+  elems: PluginElementsMap<string, unknown>,
+): string | undefined {
+  const elements = Object.keys(elems);
+  return elements.length === 1
+    ? elements[0]
+    : elements.find((key) => elems[key].asRoot);
+}
+
+/**
+ * Get the root element definition for a given block type (plugin).
+ *
+ * Each plugin defines one or more elements. The root element is either the only
+ * element in the map, or the one marked with `asRoot: true`.
+ *
+ * @param editor - YooEditor instance
+ * @param options - Options with `blockType` specifying the plugin type
+ * @returns The root PluginElement definition, or `undefined` if the plugin
+ *   doesn't exist or has no root element.
+ *
+ * @example
+ * ```typescript
+ * // Get root element of an Accordion plugin
+ * const rootElement = Elements.getRootElement(editor, { blockType: 'Accordion' });
+ *
+ * // Check if root element is void
+ * if (rootElement?.props?.nodeType === 'void') {
+ *   // handle void element
+ * }
+ * ```
+ */
+export function getRootElement(
+  editor: YooEditor,
+  options: GetRootElementOptions,
+): PluginElement<string, unknown> | undefined {
+  const plugin = editor.plugins[options.blockType];
+  if (!plugin?.elements) return undefined;
+
+  const rootElementType = resolveRootElementType(plugin.elements);
+  return rootElementType ? plugin.elements[rootElementType] : undefined;
+}

--- a/packages/core/editor/src/editor/elements/index.ts
+++ b/packages/core/editor/src/editor/elements/index.ts
@@ -6,6 +6,7 @@ import { getElementPath } from './getElementPath';
 import { getElementRect } from './getElementRect';
 import { getElements } from './getElements';
 import { getParentElementPath } from './getParentElementPath';
+import { getRootElement } from './getRootElement';
 import { insertElement } from './insertElement';
 import { isElementEmpty } from './isElementEmpty';
 import { updateElement } from './updateElement';
@@ -23,6 +24,7 @@ export const Elements = {
   getElementRect,
   getParentElementPath,
   getElementChildren,
+  getRootElement,
   isElementEmpty,
 };
 
@@ -36,6 +38,7 @@ export {
   getElementRect,
   getElements,
   getParentElementPath,
+  getRootElement,
   insertElement,
   isElementEmpty,
   updateElement,
@@ -52,6 +55,7 @@ export type {
   GetElementPathOptions,
   GetElementRectOptions,
   GetElementsOptions,
+  GetRootElementOptions,
   InsertElementOptions,
   IsElementEmptyOptions,
   UpdateElementOptions,

--- a/packages/core/editor/src/editor/elements/types.ts
+++ b/packages/core/editor/src/editor/elements/types.ts
@@ -78,6 +78,10 @@ export type GetElementRectOptions = {
   element: SlateElement;
 };
 
+export type GetRootElementOptions = {
+  blockType: string;
+};
+
 export type TransformBlockOptions = {
   blockId: string;
   transform: (slate: SlateEditor, block: YooptaBlockData) => void;

--- a/packages/core/editor/src/editor/index.tsx
+++ b/packages/core/editor/src/editor/index.tsx
@@ -42,6 +42,7 @@ import { getElementPath } from './elements/getElementPath';
 import { getElementRect } from './elements/getElementRect';
 import { getElements } from './elements/getElements';
 import { getParentElementPath } from './elements/getParentElementPath';
+import { getRootElement } from './elements/getRootElement';
 import { insertElement } from './elements/insertElement';
 import { isElementEmpty } from './elements/isElementEmpty';
 import { updateElement } from './elements/updateElement';
@@ -53,6 +54,10 @@ import {
 } from '../utils/editor-builders';
 import { generateId } from '../utils/generateId';
 import { validateYooptaValue } from '../utils/validations';
+import {
+  registerPlugin as registerPluginFn,
+  unregisterPlugin as unregisterPluginFn,
+} from './plugins/registerPlugin';
 
 export type CreateYooptaEditorOptions = {
   id?: string;
@@ -123,6 +128,7 @@ export function createYooptaEditor(opts: CreateYooptaEditorOptions): YooEditor {
     getElementRect: (options) => getElementRect(editor, options),
     getParentElementPath: (options) => getParentElementPath(editor, options),
     getElementChildren: (options) => getElementChildren(editor, options),
+    getRootElement: (options) => getRootElement(editor, options),
     isElementEmpty: (options) => isElementEmpty(editor, options),
 
     y: Object.assign(
@@ -155,6 +161,9 @@ export function createYooptaEditor(opts: CreateYooptaEditorOptions): YooEditor {
     getEmail: (content: YooptaContentValue, options?: Partial<EmailTemplateOptions>) =>
       getEmail(editor, content, options),
     getYooptaJSON: (content: YooptaContentValue) => getYooptaJSON(editor, content),
+
+    registerPlugin: (plugin) => registerPluginFn(editor, plugin),
+    unregisterPlugin: (pluginType) => unregisterPluginFn(editor, pluginType),
 
     refElement: null,
 

--- a/packages/core/editor/src/editor/plugins/loadMarketplacePlugin.test.ts
+++ b/packages/core/editor/src/editor/plugins/loadMarketplacePlugin.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { loadMarketplacePlugin } from './loadMarketplacePlugin';
+
+// ---------------------------------------------------------------------------
+// Mock dynamic import — vi.fn that we control per-test
+// ---------------------------------------------------------------------------
+
+const mockImport = vi.fn();
+
+// Replace the global import() with our mock.
+// loadMarketplacePlugin uses `import(bundleUrl)` which Vitest resolves here.
+vi.mock(
+  'virtual:marketplace-bundle',
+  () => ({ default: undefined }),
+  { virtual: true },
+);
+
+// Patch the module to use our controllable mockImport
+vi.mock('./loadMarketplacePlugin', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./loadMarketplacePlugin')>();
+  return {
+    ...original,
+    loadMarketplacePlugin: async (url: string) => {
+      const module = await mockImport(url);
+      if (!module.default) {
+        throw new Error(
+          `[Yoopta] Plugin bundle at "${url}" has no default export. ` +
+            `Expected: export default YooptaPluginInstance;`,
+        );
+      }
+      return { plugin: module.default, module };
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const FAKE_URL = 'https://marketplace.yoopta.dev/plugins/gallery/1.0.0/bundle.mjs';
+
+const fakePlugin = {
+  getPlugin: {
+    type: 'ImageGallery',
+    elements: {
+      'image-gallery': { render: vi.fn(), props: {} },
+    },
+  },
+};
+
+describe('loadMarketplacePlugin', () => {
+  it('should return plugin and module from a valid bundle', async () => {
+    mockImport.mockResolvedValueOnce({
+      default: fakePlugin,
+      ImageGalleryCommands: { insertImageGallery: vi.fn() },
+    });
+
+    const { plugin, module } = await loadMarketplacePlugin(FAKE_URL);
+
+    expect(plugin).toBe(fakePlugin);
+    expect(module.default).toBe(fakePlugin);
+    expect(module.ImageGalleryCommands).toBeDefined();
+    expect(mockImport).toHaveBeenCalledWith(FAKE_URL);
+  });
+
+  it('should throw if bundle has no default export', async () => {
+    mockImport.mockResolvedValueOnce({
+      SomeNamedExport: {},
+    });
+
+    await expect(loadMarketplacePlugin(FAKE_URL)).rejects.toThrow(
+      'has no default export',
+    );
+  });
+
+  it('should throw if bundle default export is undefined', async () => {
+    mockImport.mockResolvedValueOnce({
+      default: undefined,
+    });
+
+    await expect(loadMarketplacePlugin(FAKE_URL)).rejects.toThrow(
+      'has no default export',
+    );
+  });
+
+  it('should throw if bundle default export is null', async () => {
+    mockImport.mockResolvedValueOnce({
+      default: null,
+    });
+
+    await expect(loadMarketplacePlugin(FAKE_URL)).rejects.toThrow(
+      'has no default export',
+    );
+  });
+
+  it('should propagate network/import errors', async () => {
+    mockImport.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    await expect(loadMarketplacePlugin(FAKE_URL)).rejects.toThrow(
+      'Failed to fetch',
+    );
+  });
+
+  it('should include the URL in the error message for missing default', async () => {
+    mockImport.mockResolvedValueOnce({});
+
+    await expect(loadMarketplacePlugin(FAKE_URL)).rejects.toThrow(FAKE_URL);
+  });
+
+  it('should pass through all named exports in the module', async () => {
+    const commands = { insertGallery: vi.fn(), deleteGallery: vi.fn() };
+    const manifest = { name: 'ImageGallery', slug: 'image-gallery' };
+
+    mockImport.mockResolvedValueOnce({
+      default: fakePlugin,
+      ImageGalleryCommands: commands,
+      imageGalleryManifest: manifest,
+    });
+
+    const { module } = await loadMarketplacePlugin(FAKE_URL);
+
+    expect(module.ImageGalleryCommands).toBe(commands);
+    expect(module.imageGalleryManifest).toBe(manifest);
+  });
+});

--- a/packages/core/editor/src/editor/plugins/loadMarketplacePlugin.ts
+++ b/packages/core/editor/src/editor/plugins/loadMarketplacePlugin.ts
@@ -1,0 +1,36 @@
+import type { YooptaPlugin } from '../../plugins';
+import type { SlateElement } from '../types';
+
+export type MarketplacePluginModule = {
+  default: YooptaPlugin<Record<string, SlateElement>>;
+  [key: string]: unknown;
+}
+
+/**
+ * Dynamically loads a plugin from a URL (ESM bundle).
+ *
+ * Usage:
+ * ```ts
+ * const { plugin, module } = await loadMarketplacePlugin(
+ *   'https://marketplace.yoopta.dev/plugins/image-gallery/1.0.0/bundle.mjs'
+ * );
+ * editor.registerPlugin(plugin);
+ * ```
+ *
+ * The bundle must have a default export that is a YooptaPlugin instance.
+ */
+export async function loadMarketplacePlugin(bundleUrl: string): Promise<{
+  plugin: YooptaPlugin<Record<string, SlateElement>>;
+  module: MarketplacePluginModule;
+}> {
+  const module = (await import(/* @vite-ignore */ bundleUrl)) as MarketplacePluginModule;
+
+  if (!module.default) {
+    throw new Error(
+      `[Yoopta] Plugin bundle at "${bundleUrl}" has no default export. ` +
+      `Expected: export default YooptaPluginInstance;`,
+    );
+  }
+
+  return { plugin: module.default, module };
+}

--- a/packages/core/editor/src/editor/plugins/registerPlugin.test.ts
+++ b/packages/core/editor/src/editor/plugins/registerPlugin.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerPlugin, unregisterPlugin } from './registerPlugin';
+import type { Plugin } from '../../plugins/types';
+import { buildPlugins } from '../../utils/editor-builders';
+import type { YooEditor } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal mock objects
+// ---------------------------------------------------------------------------
+
+function mockPlugin(type: string, elements?: Record<string, any>): any {
+  return {
+    getPlugin: {
+      type,
+      elements: elements ?? {
+        [type.toLowerCase()]: {
+          render: vi.fn(),
+          props: {},
+          asRoot: true,
+        },
+      },
+    },
+  };
+}
+
+function mockEditor(
+  existingPluginTypes: string[] = ['Paragraph'],
+): YooEditor {
+  // Build real plugins via buildPlugins so injection metadata is present
+  const rawPlugins: Plugin<any>[] = existingPluginTypes.map((type) => ({
+    type,
+    elements: {
+      [type.toLowerCase()]: {
+        render: vi.fn(),
+        props: {},
+        asRoot: true,
+      },
+    },
+  }));
+
+  const plugins = buildPlugins(rawPlugins);
+
+  const emitFn = vi.fn();
+
+  return {
+    plugins,
+    children: {},
+    blockEditorsMap: {},
+    emit: emitFn,
+  } as unknown as YooEditor;
+}
+
+// ---------------------------------------------------------------------------
+// registerPlugin
+// ---------------------------------------------------------------------------
+
+describe('registerPlugin', () => {
+  let editor: YooEditor;
+
+  beforeEach(() => {
+    editor = mockEditor(['Paragraph']);
+  });
+
+  it('should add a new plugin to editor.plugins', () => {
+    const gallery = mockPlugin('ImageGallery');
+
+    registerPlugin(editor, gallery);
+
+    expect(editor.plugins).toHaveProperty('ImageGallery');
+    expect(editor.plugins.ImageGallery.type).toBe('ImageGallery');
+  });
+
+  it('should preserve existing plugins', () => {
+    const gallery = mockPlugin('ImageGallery');
+
+    registerPlugin(editor, gallery);
+
+    expect(editor.plugins).toHaveProperty('Paragraph');
+    expect(editor.plugins).toHaveProperty('ImageGallery');
+  });
+
+  it('should emit plugin:register event', () => {
+    const gallery = mockPlugin('ImageGallery');
+
+    registerPlugin(editor, gallery);
+
+    expect(editor.emit).toHaveBeenCalledWith('plugin:register', {
+      type: 'ImageGallery',
+    });
+  });
+
+  it('should not emit event if plugin is already registered', () => {
+    const paragraph = mockPlugin('Paragraph');
+
+    registerPlugin(editor, paragraph);
+
+    expect(editor.emit).not.toHaveBeenCalled();
+  });
+
+  it('should skip registration if plugin type already exists', () => {
+    const paragraph = mockPlugin('Paragraph');
+
+    registerPlugin(editor, paragraph);
+
+    // Should still have exactly the original Paragraph, not a duplicate
+    expect(Object.keys(editor.plugins).filter((k) => k === 'Paragraph')).toHaveLength(1);
+  });
+
+  it('should resolve inline element injection for new plugin', () => {
+    // Start with Paragraph + Link (inline)
+    editor = mockEditor(['Paragraph']);
+
+    // Register an inline plugin
+    const link = mockPlugin('Link', {
+      link: {
+        render: vi.fn(),
+        props: { nodeType: 'inline' },
+      },
+    });
+
+    registerPlugin(editor, link);
+
+    // Paragraph (block plugin) should now have the link inline element
+    expect(editor.plugins.Paragraph.elements).toHaveProperty('link');
+  });
+
+  it('should resolve injectElementsFromPlugins when registering the injected plugin', () => {
+    // Start with Callout that wants Paragraph injection
+    const rawCallout: Plugin<any> = {
+      type: 'Callout',
+      elements: {
+        callout: {
+          render: vi.fn(),
+          props: {},
+          asRoot: true,
+          injectElementsFromPlugins: ['Paragraph'],
+        },
+      },
+    };
+
+    editor.plugins = buildPlugins([rawCallout]);
+
+    // Now register Paragraph — Callout should get paragraph injected
+    const paragraph = mockPlugin('Paragraph');
+    registerPlugin(editor, paragraph);
+
+    expect(editor.plugins.Callout.elements).toHaveProperty('paragraph');
+  });
+
+  it('should handle multiple sequential registrations', () => {
+    const gallery = mockPlugin('ImageGallery');
+    const pricing = mockPlugin('PricingTable');
+
+    registerPlugin(editor, gallery);
+    registerPlugin(editor, pricing);
+
+    expect(editor.plugins).toHaveProperty('Paragraph');
+    expect(editor.plugins).toHaveProperty('ImageGallery');
+    expect(editor.plugins).toHaveProperty('PricingTable');
+    expect(Object.keys(editor.plugins).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unregisterPlugin
+// ---------------------------------------------------------------------------
+
+describe('unregisterPlugin', () => {
+  let editor: YooEditor;
+
+  beforeEach(() => {
+    editor = mockEditor(['Paragraph', 'ImageGallery']);
+
+    // Add some blocks of different types
+    editor.children = {
+      'block-1': {
+        id: 'block-1',
+        type: 'Paragraph',
+        value: [{ id: 'el-1', type: 'paragraph', children: [{ text: 'hello' }] }],
+        meta: { order: 0, depth: 0 },
+      },
+      'block-2': {
+        id: 'block-2',
+        type: 'ImageGallery',
+        value: [{ id: 'el-2', type: 'imagegallery', children: [{ text: '' }] }],
+        meta: { order: 1, depth: 0 },
+      },
+      'block-3': {
+        id: 'block-3',
+        type: 'ImageGallery',
+        value: [{ id: 'el-3', type: 'imagegallery', children: [{ text: '' }] }],
+        meta: { order: 2, depth: 0 },
+      },
+    };
+
+    editor.blockEditorsMap = {
+      'block-1': {} as any,
+      'block-2': {} as any,
+      'block-3': {} as any,
+    };
+  });
+
+  it('should remove the plugin from editor.plugins', () => {
+    unregisterPlugin(editor, 'ImageGallery');
+
+    expect(editor.plugins).not.toHaveProperty('ImageGallery');
+    expect(editor.plugins).toHaveProperty('Paragraph');
+  });
+
+  it('should remove all blocks of the unregistered plugin type', () => {
+    unregisterPlugin(editor, 'ImageGallery');
+
+    expect(editor.children).not.toHaveProperty('block-2');
+    expect(editor.children).not.toHaveProperty('block-3');
+    expect(editor.children).toHaveProperty('block-1');
+  });
+
+  it('should remove block editors for removed blocks', () => {
+    unregisterPlugin(editor, 'ImageGallery');
+
+    expect(editor.blockEditorsMap).not.toHaveProperty('block-2');
+    expect(editor.blockEditorsMap).not.toHaveProperty('block-3');
+    expect(editor.blockEditorsMap).toHaveProperty('block-1');
+  });
+
+  it('should emit plugin:unregister event', () => {
+    unregisterPlugin(editor, 'ImageGallery');
+
+    expect(editor.emit).toHaveBeenCalledWith('plugin:unregister', {
+      type: 'ImageGallery',
+    });
+  });
+
+  it('should not emit event if plugin does not exist', () => {
+    unregisterPlugin(editor, 'NonExistent');
+
+    expect(editor.emit).not.toHaveBeenCalled();
+  });
+
+  it('should handle unregistering when no blocks of that type exist', () => {
+    // Remove all ImageGallery blocks first
+    delete editor.children['block-2'];
+    delete editor.children['block-3'];
+
+    unregisterPlugin(editor, 'ImageGallery');
+
+    expect(editor.plugins).not.toHaveProperty('ImageGallery');
+    expect(editor.children).toHaveProperty('block-1');
+  });
+
+  it('should rebuild injection after unregistering an inline plugin', () => {
+    // Setup: Paragraph + Link (inline)
+    editor = mockEditor(['Paragraph']);
+
+    const link = mockPlugin('Link', {
+      link: {
+        render: vi.fn(),
+        props: { nodeType: 'inline' },
+      },
+    });
+    registerPlugin(editor, link);
+
+    // Verify link was injected
+    expect(editor.plugins.Paragraph.elements).toHaveProperty('link');
+
+    // Unregister Link
+    unregisterPlugin(editor, 'Link');
+
+    // Link element should be removed from Paragraph
+    expect(editor.plugins.Paragraph.elements).not.toHaveProperty('link');
+    expect(editor.plugins).not.toHaveProperty('Link');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: register then unregister
+// ---------------------------------------------------------------------------
+
+describe('register + unregister round-trip', () => {
+  it('should return editor.plugins to original state after register+unregister', () => {
+    const editor = mockEditor(['Paragraph']);
+    const originalPluginTypes = Object.keys(editor.plugins).sort();
+
+    const gallery = mockPlugin('ImageGallery');
+    registerPlugin(editor, gallery);
+
+    expect(Object.keys(editor.plugins)).toContain('ImageGallery');
+
+    unregisterPlugin(editor, 'ImageGallery');
+
+    const finalPluginTypes = Object.keys(editor.plugins)
+      .filter((k) => k !== 'ImageGallery')
+      .sort();
+
+    // Should have at least the original plugins back
+    for (const type of originalPluginTypes) {
+      expect(finalPluginTypes).toContain(type);
+    }
+    expect(editor.plugins).not.toHaveProperty('ImageGallery');
+  });
+});

--- a/packages/core/editor/src/editor/plugins/registerPlugin.ts
+++ b/packages/core/editor/src/editor/plugins/registerPlugin.ts
@@ -1,0 +1,94 @@
+import type { YooptaPlugin } from '../../plugins';
+import type { Plugin } from '../../plugins/types';
+import { buildPlugins } from '../../utils/editor-builders';
+import type { SlateElement, YooEditor } from '../types';
+
+/**
+ * Registers a plugin at runtime into an already-initialized editor.
+ *
+ * This rebuilds the full plugin map (including injection resolution)
+ * and emits a `plugin:register` event so the UI can re-render.
+ */
+export function registerPlugin(
+  editor: YooEditor,
+  pluginInput: YooptaPlugin<Record<string, SlateElement>>,
+): void {
+  const plugin = pluginInput.getPlugin as Plugin<Record<string, SlateElement>>;
+
+  if (editor.plugins[plugin.type]) {
+    return;
+  }
+
+  // Collect all existing raw plugins + the new one
+  const allPlugins = [
+    ...Object.values(editor.plugins).map(stripInjectedMetadata),
+    plugin,
+  ];
+
+  // Rebuild the full plugin map with injection resolution
+  editor.plugins = buildPlugins(allPlugins);
+
+  // Emit event for UI components (slash menu, toolbar, etc.) to update
+  editor.emit('plugin:register', { type: plugin.type });
+}
+
+/**
+ * Unregisters a plugin by type name.
+ *
+ * Removes the plugin and any blocks of that type from the editor content.
+ * Rebuilds the plugin map and emits `plugin:unregister`.
+ */
+export function unregisterPlugin(editor: YooEditor, pluginType: string): void {
+  if (!editor.plugins[pluginType]) {
+    return;
+  }
+
+  // Remove all blocks of this plugin type from content
+  const blockIdsToRemove = Object.keys(editor.children).filter(
+    (blockId) => editor.children[blockId]?.type === pluginType,
+  );
+
+  for (const blockId of blockIdsToRemove) {
+    delete editor.children[blockId];
+    delete editor.blockEditorsMap[blockId];
+  }
+
+  // Rebuild plugins without the removed one
+  const remainingPlugins = Object.values(editor.plugins)
+    .filter((p) => p.type !== pluginType)
+    .map(stripInjectedMetadata);
+
+  editor.plugins = buildPlugins(remainingPlugins);
+
+  editor.emit('plugin:unregister', { type: pluginType });
+}
+
+/**
+ * Strips injection metadata (rootPlugin, added inline elements) from a processed plugin
+ * so it can be re-processed cleanly by buildPlugins().
+ *
+ * buildPlugins() adds `rootPlugin` to injected elements and merges inline elements.
+ * Re-running it on already-processed plugins would duplicate these. We strip them
+ * and let buildPlugins() recompute from scratch.
+ */
+function stripInjectedMetadata(
+  plugin: Plugin<Record<string, SlateElement>>,
+): Plugin<Record<string, SlateElement>> {
+  if (!plugin.elements) return plugin;
+
+  const cleanElements: typeof plugin.elements = {};
+
+  for (const [key, element] of Object.entries(plugin.elements)) {
+    // Skip elements that were injected from other plugins
+    if (element.rootPlugin && element.rootPlugin !== plugin.type) {
+      continue;
+    }
+
+    // Remove rootPlugin property from own elements
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { rootPlugin, ...rest } = element as Plugin<Record<string, SlateElement>>['elements'][string] & { rootPlugin?: string };
+    cleanElements[key] = rest;
+  }
+
+  return { ...plugin, elements: cleanElements };
+}

--- a/packages/core/editor/src/editor/types.ts
+++ b/packages/core/editor/src/editor/types.ts
@@ -1,4 +1,4 @@
-import type { Descendant, NodeEntry, Path, Point, Range as SlateRange, Selection } from 'slate';
+import type { Descendant, NodeEntry, Path, Point, Selection, Range as SlateRange } from 'slate';
 import type { ReactEditor } from 'slate-react';
 
 import type { YooptaMark } from '../marks';
@@ -39,6 +39,7 @@ import type { getElementPath } from './elements/getElementPath';
 import type { getElementRect } from './elements/getElementRect';
 import type { getElements } from './elements/getElements';
 import type { getParentElementPath } from './elements/getParentElementPath';
+import type { getRootElement } from './elements/getRootElement';
 import type { insertElement } from './elements/insertElement';
 import type { isElementEmpty } from './elements/isElementEmpty';
 import type { updateElement } from './elements/updateElement';
@@ -92,7 +93,7 @@ export type YooptaBlock = {
 export type YooptaBlocks = Record<string, YooptaBlock>;
 export type YooptaFormats = Record<string, TextFormat>;
 
-export type YooptaEditorEventKeys = 'change' | 'focus' | 'blur' | 'block:copy' | 'path-change' | 'decorations:change';
+export type YooptaEditorEventKeys = 'change' | 'focus' | 'blur' | 'block:copy' | 'path-change' | 'decorations:change' | 'plugin:register' | 'plugin:unregister';
 export type YooptaEventChangePayload = {
   operations: YooptaOperation[];
   value: YooptaContentValue;
@@ -105,6 +106,8 @@ export type YooptaEventsMap = {
   'block:copy': YooptaBlockData;
   'path-change': YooptaPath;
   'decorations:change': undefined;
+  'plugin:register': { type: string };
+  'plugin:unregister': { type: string };
 };
 
 export type DecoratorFn = (blockId: string, entry: NodeEntry) => SlateRange[];
@@ -144,6 +147,7 @@ export type YooEditor = {
   getElementRect: WithoutFirstArg<typeof getElementRect>;
   getParentElementPath: WithoutFirstArg<typeof getParentElementPath>;
   getElementChildren: WithoutFirstArg<typeof getElementChildren>;
+  getRootElement: WithoutFirstArg<typeof getRootElement>;
   isElementEmpty: WithoutFirstArg<typeof isElementEmpty>;
 
   // element structure builder
@@ -211,6 +215,10 @@ export type YooEditor = {
   withSavingHistory: WithoutFirstArg<typeof YooptaHistory.withSavingHistory>;
   redo: WithoutFirstArg<typeof YooptaHistory.redo>;
   undo: WithoutFirstArg<typeof YooptaHistory.undo>;
+
+  // runtime plugin management
+  registerPlugin: (plugin: import('../plugins').YooptaPlugin<Record<string, SlateElement>>) => void;
+  unregisterPlugin: (pluginType: string) => void;
 
   // ref to editor element
   refElement: HTMLElement | null;

--- a/packages/core/editor/src/index.ts
+++ b/packages/core/editor/src/index.ts
@@ -53,6 +53,10 @@ export { buildBlockData, buildBlockElement } from './components/Editor/utils';
 export { buildBlockElementsStructure } from './utils/block-elements';
 export { buildSlateEditor } from './utils/build-slate';
 
+// Runtime plugin management
+export { loadMarketplacePlugin } from './editor/plugins/loadMarketplacePlugin';
+export type { MarketplacePluginModule } from './editor/plugins/loadMarketplacePlugin';
+
 export {
   Plugin,
   PluginElementRenderProps,


### PR DESCRIPTION
- Added the `getRootElement` function to retrieve the root element definition for a given block type in the editor, improving plugin functionality.
- Introduced runtime plugin management capabilities with `registerPlugin` and `unregisterPlugin` functions, allowing dynamic addition and removal of plugins.
- Updated relevant documentation and API references to include new methods and their usage examples.
- Enhanced test coverage for the new functionalities to ensure reliability and correctness.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
