### PR TITLE
fix(editor): resolve Turbopack "Can't resolve <dynamic>" error in loadMarketplacePlugin

### DIFF
--- a/packages/core/editor/src/editor/plugins/loadMarketplacePlugin.ts
+++ b/packages/core/editor/src/editor/plugins/loadMarketplacePlugin.ts
@@ -19,11 +19,16 @@ export type MarketplacePluginModule = {
  *
  * The bundle must have a default export that is a YooptaPlugin instance.
  */
+// Use Function constructor so bundlers (Turbopack, webpack, Rollup) cannot
+// statically analyse this import — magic comments like webpackIgnore are
+// stripped by Terser before they reach Turbopack's resolver.
+const dynamicImport = new Function('url', 'return import(url)') as (url: string) => Promise<unknown>;
+
 export async function loadMarketplacePlugin(bundleUrl: string): Promise<{
   plugin: YooptaPlugin<Record<string, SlateElement>>;
   module: MarketplacePluginModule;
 }> {
-  const module = (await import(/* @vite-ignore */ bundleUrl)) as MarketplacePluginModule;
+  const module = (await dynamicImport(bundleUrl)) as MarketplacePluginModule;
 
   if (!module.default) {
     throw new Error(


### PR DESCRIPTION
## Problem
`yarn dev` throws a build error in the Next.js playground when using Next.js 16+, 
which enables Turbopack by default:

> Module not found: Can't resolve <dynamic>
> ./packages/core/editor/dist/index.js

## Fix
Replace the dynamic `import()` with `new Function('url', 'return import(url)')`.

## Screenshot

<img width="1109" height="666" alt="Screenshot 2026-04-24 161620" src="https://github.com/user-attachments/assets/550da003-bf2d-4a4c-adbf-34a6f4654650" />
