### PR TITLE
Add toggle option to show/hide icon in Callout block

### DIFF
--- a/packages/plugins/callout/src/commands/callout-commands.ts
+++ b/packages/plugins/callout/src/commands/callout-commands.ts
@@ -26,6 +26,11 @@ export type CalloutCommands = {
   insertCallout: (editor: YooEditor, options?: Partial<InsertCalloutOptions>) => void;
   deleteCallout: (editor: YooEditor, blockId: string) => void;
   updateCalloutTheme: (editor: YooEditor, blockId: string, theme: CalloutTheme) => void;
+  updateCalloutProps: (
+    editor: YooEditor,
+    blockId: string,
+    props: Partial<CalloutElementProps>,
+  ) => void;
 };
 
 export const CalloutCommands: CalloutCommands = {
@@ -51,6 +56,12 @@ export const CalloutCommands: CalloutCommands = {
       props: {
         theme,
       },
+    });
+  },
+  updateCalloutProps: (editor: YooEditor, blockId: string, props: Partial<CalloutElementProps>) => {
+    Elements.updateElement<CalloutPluginElementKeys, CalloutElementProps>(editor, blockId, {
+      type: 'callout',
+      props,
     });
   },
 };

--- a/packages/plugins/callout/src/types.ts
+++ b/packages/plugins/callout/src/types.ts
@@ -3,7 +3,7 @@ import type { SlateElement } from '@yoopta/editor';
 export type CalloutPluginElementKeys = 'callout';
 
 export type CalloutTheme = 'default' | 'success' | 'warning' | 'error' | 'info';
-export type CalloutElementProps = { theme: CalloutTheme };
+export type CalloutElementProps = { theme: CalloutTheme; showIcon?: boolean };
 export type CalloutElement = SlateElement<'callout', CalloutElementProps>;
 
 export type CalloutElementMap = {

--- a/packages/themes/shadcn/src/callout/components/callout-element-options.tsx
+++ b/packages/themes/shadcn/src/callout/components/callout-element-options.tsx
@@ -8,16 +8,24 @@ import { AlertCircle, CheckCircle, Info, MessageSquare, XCircle } from 'lucide-r
 export const CALLOUT_THEMES = [
   { value: 'default' as const, label: 'Default', icon: <MessageSquare className="h-4 w-4" /> },
   { value: 'info' as const, label: 'Info', icon: <Info className="h-4 w-4 text-blue-500" /> },
-  { value: 'success' as const, label: 'Success', icon: <CheckCircle className="h-4 w-4 text-green-500" /> },
-  { value: 'warning' as const, label: 'Warning', icon: <AlertCircle className="h-4 w-4 text-yellow-500" /> },
+  {
+    value: 'success' as const,
+    label: 'Success',
+    icon: <CheckCircle className="h-4 w-4 text-green-500" />,
+  },
+  {
+    value: 'warning' as const,
+    label: 'Warning',
+    icon: <AlertCircle className="h-4 w-4 text-yellow-500" />,
+  },
   { value: 'error' as const, label: 'Error', icon: <XCircle className="h-4 w-4 text-red-500" /> },
 ];
 
 export type CalloutTheme = 'default' | 'success' | 'warning' | 'error' | 'info';
 
-
 type CalloutElementProps = {
   theme: CalloutTheme;
+  showIcon?: boolean;
 };
 
 export const CalloutElementOptions = () => {
@@ -52,6 +60,15 @@ export const CalloutElementOptions = () => {
             </span>
           )}
         />
+        <ElementOptions.Separator className="my-2" />
+        <ElementOptions.Group>
+          <ElementOptions.Toggle
+            label="Show icon"
+            checked={!!element.props?.showIcon}
+            onCheckedChange={(checked) => updateProps({ showIcon: checked })}
+            className="flex items-center justify-between px-2"
+          />
+        </ElementOptions.Group>
       </ElementOptions.Group>
     </ElementOptions.Content>
   );

--- a/packages/themes/shadcn/src/callout/elements/callout.tsx
+++ b/packages/themes/shadcn/src/callout/elements/callout.tsx
@@ -1,11 +1,9 @@
 import type { PluginElementRenderProps } from '@yoopta/editor';
-import {
-  ElementOptions,
-} from '@yoopta/ui/element-options';
+import { ElementOptions } from '@yoopta/ui/element-options';
 
 import { cn } from '../../utils';
 import type { CalloutTheme } from '../components/callout-element-options';
-import { CalloutElementOptions } from '../components/callout-element-options';
+import { CALLOUT_THEMES, CalloutElementOptions } from '../components/callout-element-options';
 
 const getThemeClasses = (theme: CalloutTheme = 'default'): string => {
   const themeClasses: Record<CalloutTheme, string> = {
@@ -25,21 +23,26 @@ const getThemeClasses = (theme: CalloutTheme = 'default'): string => {
 export const Callout = (props: PluginElementRenderProps) => {
   const { attributes, children, element, blockId } = props;
   const theme = (element.props?.theme as CalloutTheme) ?? 'default';
+  const showIcon = !!element.props?.showIcon;
+  const themeConfig = CALLOUT_THEMES.find((t) => t.value === theme);
 
   return (
     <div
-      {...attributes}
-      className={cn(
-        'mt-4 group relative rounded-lg border-l-4 p-4 [&>p]:m-0 [&>p]:text-sm',
+      { ...attributes }
+      className={ cn(
+        `mt-4 group relative rounded-lg border-l-4 p-4 [&>p]:m-0 [&>p]:text-sm ${showIcon ? 'pl-10' : 'pl-4'} transition-[padding] duration-300`,
         getThemeClasses(theme),
-      )}>
-      <ElementOptions.Root blockId={blockId} element={element}>
-        <ElementOptions.Trigger
-          className="absolute right-0 top-0 opacity-0 group-hover:opacity-100 transition-opacity rounded-md p-1 hover:bg-black/5 dark:hover:bg-white/10"
-        />
+      ) }>
+      <ElementOptions.Root blockId={ blockId } element={ element }>
+        <ElementOptions.Trigger className="absolute right-0 top-0 opacity-0 group-hover:opacity-100 transition-opacity rounded-md p-1 hover:bg-black/5 dark:hover:bg-white/10" />
         <CalloutElementOptions />
       </ElementOptions.Root>
-      {children}
+      { showIcon && themeConfig?.icon && (
+        <div className="mt-px absolute top-5 left-4" contentEditable={ false }>
+          { themeConfig.icon }
+        </div>
+      ) }
+      <div className="flex-1 min-w-0">{ children }</div>
     </div>
   );
 };


### PR DESCRIPTION
Closes #601

### Summary

This PR implements the feature requested in the linked issue, scoped to the `@yoopta/themes-shadcn` package. It adds a **Icon Toggle Button** in the Callout block settings popover that allows users to show or hide a themed icon on the left side of the callout.

### Changes (`@yoopta/themes-shadcn`)

- Added a **Icon Toggle** Button in the Callout block settings popover.
- Icon is **hidden by default**, maintaining full backward compatibility with existing callout blocks

### Before / After

**Before:** Callout block showed plain text with a colored left border — no icon, no theme control. Icons only shown in settings dropdown

<img width="1500" height="521" alt="Screenshot 2026-04-27 155453" src="https://github.com/user-attachments/assets/e89b6c1e-4d80-40e2-b2b5-c437382d5f3f" />

---

**After:** A "Toggle" button appears in the block settings (unchecked by default). Toggling it shows or hides the Icon

<img width="1492" height="579" alt="Screenshot 2026-04-27 164422" src="https://github.com/user-attachments/assets/10b2f4fc-a466-410f-83ab-2dc0df8e1f49" />
